### PR TITLE
Escapes TS union symbol in PanelGroup type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | `autoSaveId` | `?string`                   | Unique id used to auto-save group arrangement via `localStorage`
 | `children`   | `ReactNode[]`               | Arbitrary React element(s)
 | `className`  | `?string`                   | Class name
-| `direction`  | `"horizontal" | "vertical"` | Group orientation
+| `direction`  | `"horizontal" \| "vertical"` | Group orientation
 | `height`     | `number`                    | Height of group (in pixels)
 | `width`      | `number`                    | Width of group (in pixels)
 


### PR DESCRIPTION
## Description

Fixes a display issue for `PanelGroup` prop types where the TS union of string literals `"horizontal"` and `"vertical"` was erroneously considered a markdown column delimiter.

**Before**

![ScreenShot2022-12-22 at 19 23 01@2x](https://user-images.githubusercontent.com/17390173/209265004-74deb55f-a269-4e24-89d8-1fd3f954e219.png)

**After**

![ScreenShot2022-12-22 at 19 23 31@2x](https://user-images.githubusercontent.com/17390173/209265032-07180b36-3fd7-4083-a3fe-ff2b7a6ea3c5.png)
