### PR TITLE
Basic touch support

### DIFF
--- a/packages/react-resizable-panels/src/PanelResizeHandle.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useContext, useEffect, useState } from "react";
 
 import useUniqueId from "./hooks/useUniqueId";
 import { PanelContext, PanelGroupContext } from "./PanelContexts";
-import { ResizeHandler } from "./types";
+import type { ResizeHandler, ResizeEvent } from "./types";
 
 export default function PanelResizeHandle({
   children = null,
@@ -57,21 +57,21 @@ export default function PanelResizeHandle({
     document.body.style.cursor =
       direction === "horizontal" ? "ew-resize" : "ns-resize";
 
-    const onMouseMove = (event: MouseEvent) => {
+    const onMove = (event: ResizeEvent) => {
       resizeHandler(event);
     };
 
     document.body.addEventListener("mouseleave", stopDragging);
-    document.body.addEventListener("mousemove", onMouseMove);
-    document.body.addEventListener("touchmove", onMouseMove);
+    document.body.addEventListener("mousemove", onMove);
+    document.body.addEventListener("touchmove", onMove);
     document.body.addEventListener("mouseup", stopDragging);
 
     return () => {
       document.body.style.cursor = "";
 
       document.body.removeEventListener("mouseleave", stopDragging);
-      document.body.removeEventListener("mousemove", onMouseMove);
-      document.body.removeEventListener("touchmove", onMouseMove);
+      document.body.removeEventListener("mousemove", onMove);
+      document.body.removeEventListener("touchmove", onMove);
       document.body.removeEventListener("mouseup", stopDragging);
     };
   }, [direction, disabled, isDragging, resizeHandler, stopDragging]);

--- a/packages/react-resizable-panels/src/types.ts
+++ b/packages/react-resizable-panels/src/types.ts
@@ -7,4 +7,6 @@ export type PanelData = {
   order: number | null;
 };
 
-export type ResizeHandler = (event: MouseEvent) => void;
+export type ResizeEvent = MouseEvent | TouchEvent;
+export type DragCoordinates = { prevX: number, prevY: number };
+export type ResizeHandler = (event: ResizeEvent) => void;

--- a/packages/react-resizable-panels/src/types.ts
+++ b/packages/react-resizable-panels/src/types.ts
@@ -8,5 +8,4 @@ export type PanelData = {
 };
 
 export type ResizeEvent = MouseEvent | TouchEvent;
-export type DragCoordinates = { prevX: number, prevY: number };
 export type ResizeHandler = (event: ResizeEvent) => void;


### PR DESCRIPTION
Translate touch event to movement X and Y coordinates, so then we can reuse them to calculate movement in the same way as we do for MouseEvent

We should consider disabling the user selection while users resize panels (you can see that I can accidentally select some test inside panned while dragging the handle on mobile screen recording).


https://user-images.githubusercontent.com/61060964/209440016-b7875071-f9ad-4d58-a214-48ab8d430162.mp4


https://user-images.githubusercontent.com/61060964/209440035-005266b1-8669-4390-a3de-46c261555c9e.mp4

