### PR TITLE
fix: disable text selection on resize handle

### DIFF
--- a/packages/react-resizable-panels/src/PanelResizeHandle.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.tsx
@@ -117,6 +117,7 @@ export default function PanelResizeHandle({
       style={{
         cursor: direction === "horizontal" ? "ew-resize" : "ns-resize",
         touchAction: "none",
+        userSelect: "none",
       }}
       tabIndex={0}
     >


### PR DESCRIPTION
closes #16

disables text selection on resize handle.