### PR TITLE
Support SSR (e.g. NextJS)

### DIFF
--- a/packages/react-resizable-panels-website/src/routes/Demo/VerticalGroup.tsx
+++ b/packages/react-resizable-panels-website/src/routes/Demo/VerticalGroup.tsx
@@ -11,97 +11,105 @@ export function VerticalGroup() {
   const [showBottomPanel, setShowBottomPanel] = useState(true);
 
   return (
-    <div
-      className={styles.VerticalFiller}
-      style={{ backgroundColor: "var(--color-panel-background-alternate)" }}
-    >
-      <PanelGroup autoSaveId={GROUP_ID} direction="vertical">
-        {showTopPanel && (
-          <Panel
-            className={styles.PanelColumn}
-            defaultSize={0.35}
-            id="top"
-            minSize={0.2}
-            order={1}
-          >
-            <div className={styles.VerticalFiller}>
-              <p className={styles.ParagraphOfText}>
-                This is a "<em>vertical</em>" <code>PanelGroup</code>.
-              </p>
-              <p className={styles.ParagraphOfText}>
-                <button
-                  className={styles.Button}
-                  onClick={() => setShowTopPanel(false)}
-                >
-                  Hide panel
-                </button>
-              </p>
-            </div>
-            <PanelResizeHandle>
-              <div className={styles.VerticalResizeBar} />
-            </PanelResizeHandle>
-          </Panel>
-        )}
+    <PanelGroup autoSaveId={GROUP_ID} direction="vertical">
+      {showTopPanel && (
         <Panel
           className={styles.PanelColumn}
           defaultSize={0.35}
-          id="middle"
-          minSize={0.35}
-          order={2}
+          id="top"
+          minSize={0.2}
+          order={1}
         >
-          <div className={styles.VerticalFiller}>
+          <div
+            className={styles.VerticalFiller}
+            style={{
+              backgroundColor: "var(--color-panel-background-alternate)",
+            }}
+          >
             <p className={styles.ParagraphOfText}>
-              This panel uses the <code>minSize</code> prop to prevent it from
-              shrinking to less than 35% of the total height.
+              This is a "<em>vertical</em>" <code>PanelGroup</code>.
             </p>
-
-            {!showTopPanel && (
+            <p className={styles.ParagraphOfText}>
               <button
-                className={styles.ButtonTop}
-                onClick={() => setShowTopPanel(true)}
+                className={styles.Button}
+                onClick={() => setShowTopPanel(false)}
               >
-                Show top panel
+                Hide panel
               </button>
-            )}
+            </p>
+          </div>
+          <PanelResizeHandle>
+            <div className={styles.VerticalResizeBar} />
+          </PanelResizeHandle>
+        </Panel>
+      )}
+      <Panel
+        className={styles.PanelColumn}
+        defaultSize={0.35}
+        id="middle"
+        minSize={0.35}
+        order={2}
+      >
+        <div
+          className={styles.VerticalFiller}
+          style={{ backgroundColor: "var(--color-panel-background-alternate)" }}
+        >
+          <p className={styles.ParagraphOfText}>
+            This panel uses the <code>minSize</code> prop to prevent it from
+            shrinking to less than 35% of the total height.
+          </p>
 
-            {!showBottomPanel && (
+          {!showTopPanel && (
+            <button
+              className={styles.ButtonTop}
+              onClick={() => setShowTopPanel(true)}
+            >
+              Show top panel
+            </button>
+          )}
+
+          {!showBottomPanel && (
+            <button
+              className={styles.ButtonBottom}
+              onClick={() => setShowBottomPanel(true)}
+            >
+              Show bottom panel
+            </button>
+          )}
+        </div>
+      </Panel>
+      {showBottomPanel && (
+        <Panel
+          className={styles.PanelColumn}
+          defaultSize={0.65}
+          id="bottom"
+          minSize={0.2}
+          order={3}
+        >
+          <PanelResizeHandle>
+            <div className={styles.VerticalResizeBar} />
+          </PanelResizeHandle>
+          <div
+            className={styles.VerticalFiller}
+            style={{
+              backgroundColor: "var(--color-panel-background-alternate)",
+            }}
+          >
+            <p className={styles.ParagraphOfText}>
+              This group uses a solid resize bar, similar to Chrome devtools or
+              VS Code.
+            </p>
+            <p className={styles.ParagraphOfText}>
               <button
-                className={styles.ButtonBottom}
-                onClick={() => setShowBottomPanel(true)}
+                className={styles.Button}
+                onClick={() => setShowBottomPanel(false)}
               >
-                Show bottom panel
+                Hide panel
               </button>
-            )}
+            </p>
           </div>
         </Panel>
-        {showBottomPanel && (
-          <Panel
-            className={styles.PanelColumn}
-            defaultSize={0.65}
-            id="bottom"
-            minSize={0.2}
-            order={3}
-          >
-            <PanelResizeHandle>
-              <div className={styles.VerticalResizeBar} />
-            </PanelResizeHandle>
-            <div className={styles.VerticalFiller}>
-              <p className={styles.ParagraphOfText}>
-                This group uses a solid resize bar, similar to Chrome devtools
-                or VS Code.
-              </p>
-              <p className={styles.ParagraphOfText}>
-                <button
-                  className={styles.Button}
-                  onClick={() => setShowBottomPanel(false)}
-                >
-                  Hide panel
-                </button>
-              </p>
-            </div>
-          </Panel>
-        )}
-      </PanelGroup>
-    </div>
+      )}
+    </PanelGroup>
   );
 }

--- a/packages/react-resizable-panels-website/src/routes/Demo/styles.module.css
+++ b/packages/react-resizable-panels-website/src/routes/Demo/styles.module.css
@@ -56,7 +56,14 @@
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border-radius: 0.5rem;
+}
+.PanelColumn:first-of-type .VerticalFiller {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+.PanelColumn:last-of-type .VerticalFiller {
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
 }
 
 .PanelColumn {
@@ -101,6 +108,7 @@
   width: 100%;
   position: relative;
   padding: 0.25rem 0;
+  background-color: var(--color-panel-background-alternate);
 }
 .VerticalResizeBar::after {
   content: " ";

--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.13
+* [#18](https://github.com/bvaughn/react-resizable-panels/issues/18): Support server-side rendering (e.g. Next JS) by using `useId` (when available). `Panel` components no longer _require_ a user-provided `id` prop and will also fall back to using `useId` when none is provided.
+* `PanelGroup` component now sets `position: relative` by default.
+
 ## 0.0.12
 * Bug fix: [#19](https://github.com/bvaughn/react-resizable-panels/issues/19): Fix initial "jump" that could occur when dragging started.
 * Bug fix: [#20](https://github.com/bvaughn/react-resizable-panels/issues/20): Stop resize/drag operation on "contextmenu" event.

--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.0.13
 * [#18](https://github.com/bvaughn/react-resizable-panels/issues/18): Support server-side rendering (e.g. Next JS) by using `useId` (when available). `Panel` components no longer _require_ a user-provided `id` prop and will also fall back to using `useId` when none is provided.
-* `PanelGroup` component now sets `position: relative` by default.
+* `PanelGroup` component now sets `position: relative` style by default, as well as an explicit `height` and `width` style.
 
 ## 0.0.12
 * Bug fix: [#19](https://github.com/bvaughn/react-resizable-panels/issues/19): Fix initial "jump" that could occur when dragging started.

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -29,6 +29,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | `className`  | `?string`                   | Class name
 | `direction`  | `"horizontal" \| "vertical"` | Group orientation
 | `height`     | `number`                    | Height of group (in pixels)
+| `id`         | `?string`                   | Optional group id; falls back to `useId` when not provided
 | `width`      | `number`                    | Width of group (in pixels)
 
 ### `Panel`
@@ -37,7 +38,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | `children`    | `ReactNode` | Arbitrary React element(s)
 | `className`   | `?string`   | Class name
 | `defaultSize` | `?number`   | Initial size of panel (relative to other panels within the group)
-| `id`          | `string`    | Panel id (must be unique within the current group)
+| `id`          | `?string`   | Optional panel id (unique within group); falls back to `useId` when not provided
 | `minSize`     | `?number`   | Minum allowable size of panel (0.0 - 1.0)
 | `order`       | `?number`   | Order of panel within group; required for groups with conditionally rendered panels
 
@@ -47,7 +48,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | `children`    | `?ReactNode` | Custom drag UI; can be any arbitrary React element(s)
 | `className`   | `?string`    | Class name
 | `disabled`    | `?boolean`   | Disable drag handle
-| `id`          | `?string`    | Optional resize handle id (must be unique within the current group)
+| `id`          | `?string`    | Optional resize handle id (unique within group); falls back to `useId` when not provided
 
 ### `PanelContext`
 | prop         | type                 | description

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -5,15 +5,15 @@ React components for resizable panel groups/layouts
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 <PanelGroup autoSaveId="example" direction="horizontal">
-  <Panel defaultSize={0.3} id="left">
+  <Panel defaultSize={0.3}>
     <SourcesExplorer />
   </Panel>
-  <Panel defaultSize={0.5} id="middle">
+  <Panel defaultSize={0.5}>
     <PanelResizeHandle />
     <SourceViewer />
     <PanelResizeHandle />
   </Panel>
-  <Panel defaultSize={0.2} id="right">
+  <Panel defaultSize={0.2}>
     <Console />
   </Panel>
 </PanelGroup>

--- a/packages/react-resizable-panels/src/Panel.tsx
+++ b/packages/react-resizable-panels/src/Panel.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useContext, useLayoutEffect } from "react";
+import useUniqueId from "./hooks/useUniqueId";
 
 import { PanelGroupContext } from "./PanelContexts";
 
@@ -9,14 +10,14 @@ export default function Panel({
   children = null,
   className = "",
   defaultSize = 0.1,
-  id,
+  id: idFromProps = null,
   minSize = 0.1,
   order = null,
 }: {
   children?: ReactNode;
   className?: string;
   defaultSize?: number;
-  id: string;
+  id?: string | null;
   minSize?: number;
   order?: number | null;
 }) {
@@ -26,6 +27,8 @@ export default function Panel({
       `Panel components must be rendered within a PanelGroup container`
     );
   }
+
+  const panelId = useUniqueId(idFromProps);
 
   if (minSize > defaultSize) {
     console.error(
@@ -40,25 +43,25 @@ export default function Panel({
   useLayoutEffect(() => {
     const panel = {
       defaultSize,
-      id,
+      id: panelId,
       minSize,
       order,
     };
 
-    registerPanel(id, panel);
+    registerPanel(panelId, panel);
 
     return () => {
-      unregisterPanel(id);
+      unregisterPanel(panelId);
     };
-  }, [defaultSize, id, minSize, order, registerPanel, unregisterPanel]);
+  }, [defaultSize, panelId, minSize, order, registerPanel, unregisterPanel]);
 
-  const style = getPanelStyle(id);
+  const style = getPanelStyle(panelId);
 
   return (
     <div
       className={className}
-      data-panel-id={id}
-      id={`data-panel-id-${id}`}
+      data-panel-id={panelId}
+      id={`data-panel-id-${panelId}`}
       style={style}
     >
       {children}

--- a/packages/react-resizable-panels/src/PanelGroup.tsx
+++ b/packages/react-resizable-panels/src/PanelGroup.tsx
@@ -281,7 +281,7 @@ export default function PanelGroup({
         <div
           className={className}
           data-panel-group-id={groupId}
-          style={{ position: "relative" }}
+          style={{ height, position: "relative", width }}
         >
           {children}
         </div>

--- a/packages/react-resizable-panels/src/PanelGroup.tsx
+++ b/packages/react-resizable-panels/src/PanelGroup.tsx
@@ -8,7 +8,6 @@ import {
   useRef,
   useState,
 } from "react";
-import useUniqueId from "./hooks/useUniqueId";
 
 import { PanelContext, PanelGroupContext } from "./PanelContexts";
 import { Direction, PanelData, ResizeEvent } from "./types";
@@ -22,6 +21,7 @@ import {
   panelsMapToSortedArray,
 } from "./utils/group";
 import { useWindowSplitterPanelGroupBehavior } from "./hooks/useWindowSplitterBehavior";
+import useUniqueId from "./hooks/useUniqueId";
 
 export type CommittedValues = {
   direction: Direction;
@@ -39,6 +39,7 @@ type Props = {
   className?: string;
   direction: Direction;
   height: number;
+  id?: string | null;
   width: number;
 };
 
@@ -52,9 +53,10 @@ export default function PanelGroup({
   className = "",
   direction,
   height,
+  id: idFromProps = null,
   width,
 }: Props) {
-  const groupId = useUniqueId();
+  const groupId = useUniqueId(idFromProps);
 
   const [activeHandleId, setActiveHandleId] = useState<string | null>(null);
   const [panels, setPanels] = useState<PanelDataMap>(new Map());
@@ -276,7 +278,13 @@ export default function PanelGroup({
   return (
     <PanelContext.Provider value={panelContext}>
       <PanelGroupContext.Provider value={panelGroupContext}>
-        <div className={className}>{children}</div>
+        <div
+          className={className}
+          data-panel-group-id={groupId}
+          style={{ position: "relative" }}
+        >
+          {children}
+        </div>
       </PanelGroupContext.Provider>
     </PanelContext.Provider>
   );

--- a/packages/react-resizable-panels/src/PanelResizeHandle.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.tsx
@@ -6,8 +6,8 @@ import {
   useRef,
   useState,
 } from "react";
-
 import useUniqueId from "./hooks/useUniqueId";
+
 import { useWindowSplitterResizeHandlerBehavior } from "./hooks/useWindowSplitterBehavior";
 import { PanelContext, PanelGroupContext } from "./PanelContexts";
 import type { ResizeHandler, ResizeEvent } from "./types";
@@ -16,7 +16,7 @@ export default function PanelResizeHandle({
   children = null,
   className = "",
   disabled = false,
-  id: idProp = null,
+  id: idFromProps = null,
 }: {
   children?: ReactNode;
   className?: string;
@@ -33,8 +33,6 @@ export default function PanelResizeHandle({
     );
   }
 
-  const id = useUniqueId(idProp);
-
   const { activeHandleId } = panelContext;
   const {
     direction,
@@ -44,7 +42,8 @@ export default function PanelResizeHandle({
     stopDragging,
   } = panelGroupContext;
 
-  const isDragging = activeHandleId === id;
+  const resizeHandleId = useUniqueId(idFromProps);
+  const isDragging = activeHandleId === resizeHandleId;
 
   const [resizeHandler, setResizeHandler] = useState<ResizeHandler | null>(
     null
@@ -63,10 +62,10 @@ export default function PanelResizeHandle({
     if (disabled) {
       setResizeHandler(null);
     } else {
-      const resizeHandler = registerResizeHandle(id);
+      const resizeHandler = registerResizeHandle(resizeHandleId);
       setResizeHandler(() => resizeHandler);
     }
-  }, [disabled, id, registerResizeHandle]);
+  }, [disabled, resizeHandleId, registerResizeHandle]);
 
   useEffect(() => {
     if (disabled || resizeHandler == null || !isDragging) {
@@ -99,7 +98,7 @@ export default function PanelResizeHandle({
 
   useWindowSplitterResizeHandlerBehavior({
     disabled,
-    handleId: id,
+    handleId: resizeHandleId,
     resizeHandler,
   });
 
@@ -108,12 +107,12 @@ export default function PanelResizeHandle({
       className={className}
       data-panel-group-id={groupId}
       data-panel-resize-handle-enabled={!disabled}
-      data-panel-resize-handle-id={id}
-      onMouseDown={(event) => startDragging(id, event.nativeEvent)}
+      data-panel-resize-handle-id={resizeHandleId}
+      onMouseDown={(event) => startDragging(resizeHandleId, event.nativeEvent)}
       onMouseUp={stopDraggingAndBlur}
       onTouchCancel={stopDraggingAndBlur}
       onTouchEnd={stopDraggingAndBlur}
-      onTouchStart={(event) => startDragging(id, event.nativeEvent)}
+      onTouchStart={(event) => startDragging(resizeHandleId, event.nativeEvent)}
       ref={divElementRef}
       role="separator"
       style={{

--- a/packages/react-resizable-panels/src/hooks/useUniqueId.ts
+++ b/packages/react-resizable-panels/src/hooks/useUniqueId.ts
@@ -1,9 +1,13 @@
-import { useRef } from "react";
+import { useId, useRef } from "react";
 
 let counter = 0;
 
-export default function useUniqueId(id: string | null = null): string {
-  const idRef = useRef<string | null>(id);
+export default function useUniqueId(
+  idFromParams: string | null = null
+): string {
+  const idFromUseId = typeof useId === "function" ? useId() : null;
+
+  const idRef = useRef<string | null>(idFromParams || idFromUseId || null);
   if (idRef.current === null) {
     idRef.current = "" + counter++;
   }


### PR DESCRIPTION
* Use [`useId`](https://beta.reactjs.org/reference/react/useId) hook (when available) to generate ids for panels/groups/resize handles.
* `Panel` component no longer _requires_ an id prop (falling back to `useId` if none is provided).
* `PanelGroup` component sets default style `position: relative`

Resolves #18