### PR TITLE
 uses  rather than absolute positioning

### DIFF
--- a/packages/react-resizable-panels-website/index.tsx
+++ b/packages/react-resizable-panels-website/index.tsx
@@ -39,7 +39,7 @@ const router = createBrowserRouter([
 const rootElement = document.getElementById("root");
 const root = createRoot(rootElement);
 root.render(
-  // <StrictMode>
-  <RouterProvider router={router} />
-  // </StrictMode>
+  <StrictMode>
+    <RouterProvider router={router} />
+  </StrictMode>
 );

--- a/packages/react-resizable-panels-website/index.tsx
+++ b/packages/react-resizable-panels-website/index.tsx
@@ -39,7 +39,7 @@ const router = createBrowserRouter([
 const rootElement = document.getElementById("root");
 const root = createRoot(rootElement);
 root.render(
-  <StrictMode>
-    <RouterProvider router={router} />
-  </StrictMode>
+  // <StrictMode>
+  <RouterProvider router={router} />
+  // </StrictMode>
 );

--- a/packages/react-resizable-panels-website/src/components/AutoSizedPanelGroup.tsx
+++ b/packages/react-resizable-panels-website/src/components/AutoSizedPanelGroup.tsx
@@ -1,7 +1,0 @@
-import { PanelGroup } from "react-resizable-panels";
-
-import withAutoSizer from "../utils/withAutoSizer";
-
-const AutoSizedPanelGroup = withAutoSizer(PanelGroup);
-
-export default AutoSizedPanelGroup;

--- a/packages/react-resizable-panels-website/src/routes/examples/Conditional.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Conditional.tsx
@@ -34,7 +34,7 @@ export default function ConditionalRoute() {
               {showLeftPanel ? "Hide" : "Show"} left panel
             </button>{" "}
             <button onClick={() => setShowRightPanel(!showRightPanel)}>
-              {showLeftPanel ? "Hide" : "Show"} right panel
+              {showRightPanel ? "Hide" : "Show"} right panel
             </button>
           </p>
         </>

--- a/packages/react-resizable-panels-website/src/routes/examples/Conditional.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Conditional.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
-import { Panel } from "react-resizable-panels";
+import { Panel, PanelGroup } from "react-resizable-panels";
 
-import PanelGroup from "../../components/AutoSizedPanelGroup";
 import ResizeHandle from "../../components/ResizeHandle";
 
 import Example from "./Example";
@@ -59,34 +58,23 @@ function Content({
         direction="horizontal"
       >
         {showLeftPanel && (
-          <Panel
-            className={styles.Panel}
-            defaultSize={0.2}
-            minSize={0.2}
-            order={1}
-          >
-            <div className={styles.Centered}>left</div>
+          <>
+            <Panel className={styles.Panel} order={1}>
+              <div className={styles.Centered}>left</div>
+            </Panel>
             <ResizeHandle className={styles.ResizeHandle} />
-          </Panel>
+          </>
         )}
-        <Panel
-          className={styles.Panel}
-          defaultSize={0.3}
-          minSize={0.3}
-          order={2}
-        >
+        <Panel className={styles.Panel} order={2}>
           <div className={styles.Centered}>middle</div>
         </Panel>
         {showRightPanel && (
-          <Panel
-            className={styles.Panel}
-            defaultSize={0.21}
-            minSize={0.21}
-            order={3}
-          >
+          <>
             <ResizeHandle className={styles.ResizeHandle} />
-            <div className={styles.Centered}>right</div>
-          </Panel>
+            <Panel className={styles.Panel} order={3}>
+              <div className={styles.Centered}>right</div>
+            </Panel>
+          </>
         )}
       </PanelGroup>
     </div>
@@ -96,19 +84,23 @@ function Content({
 const CODE = `
 <PanelGroup autoSaveId="conditional" direction="horizontal">
   {showLeftPanel && (
-    <Panel order={1}>
-      <div>left</div>
+    <>
+      <Panel order={1}>
+        left
+      </Panel>
       <ResizeHandle />
-    </Panel>
+    </>
   )}
   <Panel order={2}>
-    <div>middle</div>
+    middle
   </Panel>
   {showRightPanel && (
-    <Panel order={3}>
+    <>
       <ResizeHandle />
-      <div>right</div>
-    </Panel>
+      <Panel order={3}>
+        right
+      </Panel>
+    </>
   )}
 </PanelGroup>
 `;

--- a/packages/react-resizable-panels-website/src/routes/examples/Horizontal.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Horizontal.tsx
@@ -1,6 +1,5 @@
-import { Panel } from "react-resizable-panels";
+import { Panel, PanelGroup } from "react-resizable-panels";
 
-import PanelGroup from "../../components/AutoSizedPanelGroup";
 import ResizeHandle from "../../components/ResizeHandle";
 
 import Example from "./Example";
@@ -26,15 +25,15 @@ function Content() {
   return (
     <div className={styles.PanelGroupWrapper}>
       <PanelGroup className={styles.PanelGroup} direction="horizontal">
-        <Panel className={styles.PanelRow} defaultSize={0.2} minSize={0.2}>
+        <Panel className={styles.PanelRow} defaultSize={20} minSize={20}>
           <div className={styles.Centered}>left</div>
-          <ResizeHandle className={styles.ResizeHandle} />
         </Panel>
-        <Panel className={styles.PanelRow} defaultSize={0.4} minSize={0.2}>
+        <ResizeHandle className={styles.ResizeHandle} />
+        <Panel className={styles.PanelRow} minSize={30}>
           <div className={styles.Centered}>middle</div>
         </Panel>
-        <Panel className={styles.PanelRow} defaultSize={0.2} minSize={0.2}>
-          <ResizeHandle className={styles.ResizeHandle} />
+        <ResizeHandle className={styles.ResizeHandle} />
+        <Panel className={styles.PanelRow} defaultSize={20} minSize={20}>
           <div className={styles.Centered}>right</div>
         </Panel>
       </PanelGroup>
@@ -44,16 +43,16 @@ function Content() {
 
 const CODE = `
 <PanelGroup direction="horizontal">
-  <Panel>
-    <div>left</div>
-    <ResizeHandle />
+  <Panel defaultSize={20} minSize={20}>
+    left
   </Panel>
-  <Panel>
-    <div>middle</div>
+  <ResizeHandle />
+  <Panel minSize={30}>
+    middle
   </Panel>
-  <Panel>
-    <ResizeHandle />
-    <div>right</div>
+  <ResizeHandle />
+  <Panel defaultSize={20} minSize={20}>
+    right
   </Panel>
 </PanelGroup>
 `;

--- a/packages/react-resizable-panels-website/src/routes/examples/Nested.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Nested.tsx
@@ -1,6 +1,5 @@
-import { Panel } from "react-resizable-panels";
+import { Panel, PanelGroup } from "react-resizable-panels";
 
-import PanelGroup from "../../components/AutoSizedPanelGroup";
 import ResizeHandle from "../../components/ResizeHandle";
 
 import Example from "./Example";
@@ -20,47 +19,31 @@ function Content() {
   return (
     <div className={styles.PanelGroupWrapper}>
       <PanelGroup className={styles.PanelGroup} direction="horizontal">
-        <Panel className={styles.PanelRow} defaultSize={0.2} minSize={0.2}>
+        <Panel className={styles.PanelRow} defaultSize={20}>
           <div className={styles.Centered}>left</div>
-          <ResizeHandle className={styles.ResizeHandle} />
         </Panel>
-        <Panel className={styles.PanelRow} defaultSize={0.4} minSize={0.2}>
+        <ResizeHandle className={styles.ResizeHandle} />
+        <Panel className={styles.PanelRow} minSize={35}>
           <PanelGroup className={styles.PanelGroup} direction="vertical">
-            <Panel
-              className={styles.PanelColumn}
-              defaultSize={0.35}
-              minSize={0.35}
-            >
+            <Panel className={styles.PanelColumn} defaultSize={35}>
               <div className={styles.Centered}>top</div>
-              <ResizeHandle className={styles.ResizeHandle} />
             </Panel>
-            <Panel
-              className={styles.PanelColumn}
-              defaultSize={0.35}
-              minSize={0.35}
-            >
+            <ResizeHandle className={styles.ResizeHandle} />
+            <Panel className={styles.PanelColumn}>
               <PanelGroup className={styles.PanelGroup} direction="horizontal">
-                <Panel
-                  className={styles.PanelRow}
-                  defaultSize={0.2}
-                  minSize={0.2}
-                >
+                <Panel className={styles.PanelRow}>
                   <div className={styles.Centered}>left</div>
-                  <ResizeHandle className={styles.ResizeHandle} />
                 </Panel>
-                <Panel
-                  className={styles.PanelRow}
-                  defaultSize={0.2}
-                  minSize={0.2}
-                >
+                <ResizeHandle className={styles.ResizeHandle} />
+                <Panel className={styles.PanelRow}>
                   <div className={styles.Centered}>right</div>
                 </Panel>
               </PanelGroup>
             </Panel>
           </PanelGroup>
         </Panel>
-        <Panel className={styles.PanelRow} defaultSize={0.2} minSize={0.2}>
-          <ResizeHandle className={styles.ResizeHandle} />
+        <ResizeHandle className={styles.ResizeHandle} />
+        <Panel className={styles.PanelRow} defaultSize={20}>
           <div className={styles.Centered}>right</div>
         </Panel>
       </PanelGroup>
@@ -71,36 +54,31 @@ function Content() {
 const CODE = `
 <PanelGroup direction="horizontal">
   <Panel>
-    <div>left</div>
-    <ResizeHandle />
+    left
   </Panel>
+  <ResizeHandle />
   <Panel>
-    <div>
     <PanelGroup direction="vertical">
       <Panel>
-        <div>top</div>
-        <ResizeHandle />
+        top
       </Panel>
+      <ResizeHandle />
       <Panel>
-        <ResizeHandle />
-        <div>
-          <PanelGroup direction="horizontal">
-            <Panel>
-              <div>left</div>
-              <ResizeHandle />
-            </Panel>
-            <Panel>
-              <div>right</div>
-            </Panel>
-          </PanelGroup>
-        </div>
+        <PanelGroup direction="horizontal">
+          <Panel>
+            left
+          </Panel>
+          <ResizeHandle />
+          <Panel>
+            right
+          </Panel>
+        </PanelGroup>
       </Panel>
     </PanelGroup>
-    </div>
   </Panel>
+  <ResizeHandle />
   <Panel>
-    <ResizeHandle />
-    <div>right</div>
+    right
   </Panel>
 </PanelGroup>
 `;

--- a/packages/react-resizable-panels-website/src/routes/examples/Persistence.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Persistence.tsx
@@ -32,11 +32,11 @@ function Content() {
         <Panel className={styles.PanelColumn}>
           <div className={styles.Centered}>left</div>
         </Panel>
+        <ResizeHandle className={styles.ResizeHandle} />
         <Panel className={styles.PanelRow}>
-          <ResizeHandle className={styles.ResizeHandle} />
           <div className={styles.Centered}>middle</div>
-          <ResizeHandle className={styles.ResizeHandle} />
         </Panel>
+        <ResizeHandle className={styles.ResizeHandle} />
         <Panel className={styles.PanelColumn}>
           <div className={styles.Centered}>right</div>
         </Panel>

--- a/packages/react-resizable-panels-website/src/routes/examples/Persistence.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Persistence.tsx
@@ -1,6 +1,5 @@
-import { Panel } from "react-resizable-panels";
+import { Panel, PanelGroup } from "react-resizable-panels";
 
-import PanelGroup from "../../components/AutoSizedPanelGroup";
 import ResizeHandle from "../../components/ResizeHandle";
 
 import Example from "./Example";
@@ -30,15 +29,15 @@ function Content() {
         className={styles.PanelGroup}
         direction="horizontal"
       >
-        <Panel className={styles.PanelColumn} defaultSize={0.2} minSize={0.2}>
+        <Panel className={styles.PanelColumn}>
           <div className={styles.Centered}>left</div>
         </Panel>
-        <Panel className={styles.PanelRow} defaultSize={0.2} minSize={0.2}>
+        <Panel className={styles.PanelRow}>
           <ResizeHandle className={styles.ResizeHandle} />
           <div className={styles.Centered}>middle</div>
           <ResizeHandle className={styles.ResizeHandle} />
         </Panel>
-        <Panel className={styles.PanelColumn} defaultSize={0.2} minSize={0.2}>
+        <Panel className={styles.PanelColumn}>
           <div className={styles.Centered}>right</div>
         </Panel>
       </PanelGroup>
@@ -49,15 +48,15 @@ function Content() {
 const CODE = `
 <PanelGroup autoSaveId="persistence" direction="horizontal">
   <Panel>
-    <div>left</div>
+    left
   </Panel>
+  <ResizeHandle />
   <Panel>
-    <ResizeHandle />
-    <div>middle</div>
-    <ResizeHandle />
+    middle
   </Panel>
+  <ResizeHandle />
   <Panel>
-    <div>right</div>
+    right
   </Panel>
 </PanelGroup>
 `;

--- a/packages/react-resizable-panels-website/src/routes/examples/Vertical.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Vertical.tsx
@@ -1,6 +1,5 @@
-import { Panel } from "react-resizable-panels";
+import { Panel, PanelGroup } from "react-resizable-panels";
 
-import PanelGroup from "../../components/AutoSizedPanelGroup";
 import ResizeHandle from "../../components/ResizeHandle";
 
 import Example from "./Example";
@@ -26,11 +25,11 @@ function Content() {
   return (
     <div className={styles.PanelGroupWrapper}>
       <PanelGroup className={styles.PanelGroup} direction="vertical">
-        <Panel className={styles.PanelColumn} defaultSize={0.35} minSize={0.35}>
+        <Panel className={styles.PanelColumn} defaultSize={50}>
           <div className={styles.Centered}>top</div>
-          <ResizeHandle className={styles.ResizeHandle} />
         </Panel>
-        <Panel className={styles.PanelColumn} defaultSize={0.35} minSize={0.35}>
+        <ResizeHandle className={styles.ResizeHandle} />
+        <Panel className={styles.PanelColumn}>
           <div className={styles.Centered}>bottom</div>
         </Panel>
       </PanelGroup>
@@ -41,11 +40,11 @@ function Content() {
 const CODE = `
 <PanelGroup direction="vertical">
   <Panel>
-    <div>top</div>
-    <ResizeHandle />
+    top
   </Panel>
+  <ResizeHandle />
   <Panel>
-    <div>bottom</div>
+    bottom
   </Panel>
 </PanelGroup>
 `;

--- a/packages/react-resizable-panels-website/src/routes/examples/shared.module.css
+++ b/packages/react-resizable-panels-website/src/routes/examples/shared.module.css
@@ -1,5 +1,5 @@
 .PanelGroupWrapper {
-  height: 15rem;
+  height: 20rem;
 }
 
 .PanelGroup {

--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.15
+* [#30](https://github.com/bvaughn/react-resizable-panels/issues/30): `PanelGroup` uses `display: flex` rather than absolute positioning. This provides several benefits: (a) more responsive resizing for nested groups, (b) no explicit `width`/`height` props, and (c) `PanelResizeHandle` components can now be rendered directly within `PanelGroup` (rather than as children of `Panel`s).
+
 ## 0.0.14
 * [#23](https://github.com/bvaughn/react-resizable-panels/issues/23): Fix small regression with `autoSaveId` that was introduced with non-deterministic `useId` ids.
 

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -5,15 +5,15 @@ React components for resizable panel groups/layouts
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 <PanelGroup autoSaveId="example" direction="horizontal">
-  <Panel defaultSize={0.3}>
+  <Panel defaultSize={25}>
     <SourcesExplorer />
   </Panel>
-  <Panel defaultSize={0.5}>
-    <PanelResizeHandle />
+  <PanelResizeHandle />
+  <Panel>
     <SourceViewer />
-    <PanelResizeHandle />
   </Panel>
-  <Panel defaultSize={0.2}>
+  <PanelResizeHandle />
+  <Panel defaultSize={25}>
     <Console />
   </Panel>
 </PanelGroup>
@@ -28,18 +28,16 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | `children`   | `ReactNode`                 | Arbitrary React element(s)
 | `className`  | `?string`                   | Class name
 | `direction`  | `"horizontal" \| "vertical"` | Group orientation
-| `height`     | `number`                    | Height of group (in pixels)
 | `id`         | `?string`                   | Optional group id; falls back to `useId` when not provided
-| `width`      | `number`                    | Width of group (in pixels)
 
 ### `Panel`
 | prop          | type        | description
 | :------------ | :---------- | :---
 | `children`    | `ReactNode` | Arbitrary React element(s)
 | `className`   | `?string`   | Class name
-| `defaultSize` | `?number`   | Initial size of panel (relative to other panels within the group)
+| `defaultSize` | `?number`   | Initial size of panel (numeric value between 1-100)
 | `id`          | `?string`   | Optional panel id (unique within group); falls back to `useId` when not provided
-| `minSize`     | `?number`   | Minum allowable size of panel (0.0 - 1.0)
+| `minSize`     | `?number`   | Minimum allowable size of panel (numeric value between 1-100)
 | `order`       | `?number`   | Order of panel within group; required for groups with conditionally rendered panels
 
 ### `PanelResizeHandle`

--- a/packages/react-resizable-panels/src/Panel.tsx
+++ b/packages/react-resizable-panels/src/Panel.tsx
@@ -30,6 +30,10 @@ export default function Panel({
 
   const panelId = useUniqueId(idFromProps);
 
+  if (minSize < 0 || minSize > 100) {
+    throw Error(`Panel minSize must be between 0 and 100, but was ${minSize}`);
+  }
+
   if (defaultSize !== null) {
     if (defaultSize < 0 || defaultSize > 100) {
       throw Error(

--- a/packages/react-resizable-panels/src/Panel.tsx
+++ b/packages/react-resizable-panels/src/Panel.tsx
@@ -9,14 +9,14 @@ import { PanelGroupContext } from "./PanelContexts";
 export default function Panel({
   children = null,
   className = "",
-  defaultSize = 0.1,
+  defaultSize = null,
   id: idFromProps = null,
-  minSize = 0.1,
+  minSize = 10,
   order = null,
 }: {
   children?: ReactNode;
   className?: string;
-  defaultSize?: number;
+  defaultSize?: number | null;
   id?: string | null;
   minSize?: number;
   order?: number | null;
@@ -30,12 +30,18 @@ export default function Panel({
 
   const panelId = useUniqueId(idFromProps);
 
-  if (minSize > defaultSize) {
-    console.error(
-      `Panel minSize ${minSize} cannot be greater than defaultSize ${defaultSize}`
-    );
+  if (defaultSize !== null) {
+    if (defaultSize < 0 || defaultSize > 100) {
+      throw Error(
+        `Panel defaultSize must be between 0 and 100, but was ${defaultSize}`
+      );
+    } else if (minSize > defaultSize) {
+      console.error(
+        `Panel minSize ${minSize} cannot be greater than defaultSize ${defaultSize}`
+      );
 
-    defaultSize = minSize;
+      defaultSize = minSize;
+    }
   }
 
   const { getPanelStyle, registerPanel, unregisterPanel } = context;

--- a/packages/react-resizable-panels/src/PanelGroup.tsx
+++ b/packages/react-resizable-panels/src/PanelGroup.tsx
@@ -117,7 +117,11 @@ export default function PanelGroup({
         }
       });
 
-      if (totalMinSize > 100) {
+      if (totalDefaultSize > 100) {
+        throw new Error(
+          `The sum of the defaultSize of all panels in a group cannot exceed 100.`
+        );
+      } else if (totalMinSize > 100) {
         throw new Error(
           `The sum of the minSize of all panels in a group cannot exceed 100.`
         );

--- a/packages/react-resizable-panels/src/PanelGroup.tsx
+++ b/packages/react-resizable-panels/src/PanelGroup.tsx
@@ -90,8 +90,6 @@ export default function PanelGroup({
       return;
     }
 
-    // TODO [issues/30] Validate that the total minSize is <= 100.
-
     // If this panel has been configured to persist sizing information,
     // default size should be restored from local storage if possible.
     let defaultSizes: number[] | undefined = undefined;
@@ -107,14 +105,23 @@ export default function PanelGroup({
 
       let panelsWithNullDefaultSize = 0;
       let totalDefaultSize = 0;
+      let totalMinSize = 0;
 
       panelsArray.forEach((panel) => {
+        totalMinSize += panel.minSize;
+
         if (panel.defaultSize === null) {
           panelsWithNullDefaultSize++;
         } else {
           totalDefaultSize += panel.defaultSize;
         }
       });
+
+      if (totalMinSize > 100) {
+        throw new Error(
+          `The sum of the minSize of all panels in a group cannot exceed 100.`
+        );
+      }
 
       setSizes(
         panelsArray.map((panel) => {

--- a/packages/react-resizable-panels/src/constants.ts
+++ b/packages/react-resizable-panels/src/constants.ts
@@ -1,1 +1,1 @@
-export const PRECISION = 5;
+export const PRECISION = 10;

--- a/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
+++ b/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
@@ -6,12 +6,13 @@ import { ResizeHandler } from "../types";
 import {
   adjustByDelta,
   getPanel,
+  getPanelGroup,
   getResizeHandle,
   getResizeHandleIndex,
   getResizeHandlePanelIds,
   getResizeHandles,
   getResizeHandlesForGroup,
-  getSize,
+  getFlexGrow,
   panelsMapToSortedArray,
 } from "../utils/group";
 
@@ -31,7 +32,10 @@ export function useWindowSplitterPanelGroupBehavior({
   sizes: number[];
 }): void {
   useEffect(() => {
-    const { direction, height, panels, width } = committedValuesRef.current;
+    const { direction, panels } = committedValuesRef.current;
+
+    const groupElement = getPanelGroup(groupId);
+    const { height, width } = groupElement.getBoundingClientRect();
 
     const handles = getResizeHandlesForGroup(groupId);
     const cleanupFunctions = handles.map((handle) => {
@@ -57,12 +61,11 @@ export function useWindowSplitterPanelGroupBehavior({
       const ariaValueMin =
         panelsArray.find((panel) => panel.id == idBefore)?.minSize ?? 0;
 
-      const size = getSize(panels, idBefore, direction, sizes, height, width);
-      const ariaValueNow = size / (direction === "horizontal" ? width : height);
+      const size = getFlexGrow(panels, idBefore, sizes);
 
       handle.setAttribute("aria-valuemax", "" + Math.round(100 * ariaValueMax));
       handle.setAttribute("aria-valuemin", "" + Math.round(100 * ariaValueMin));
-      handle.setAttribute("aria-valuenow", "" + Math.round(100 * ariaValueNow));
+      handle.setAttribute("aria-valuenow", "" + size);
 
       const onKeyDown = (event: KeyboardEvent) => {
         switch (event.key) {

--- a/packages/react-resizable-panels/src/utils/coordinates.ts
+++ b/packages/react-resizable-panels/src/utils/coordinates.ts
@@ -1,5 +1,5 @@
 import { Direction, ResizeEvent } from "../types";
-import { getResizeHandle } from "./group";
+import { getPanelGroup, getResizeHandle } from "./group";
 
 export type Coordinates = {
   movement: number;
@@ -39,13 +39,16 @@ export function getDragOffset(
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/movementX
 export function getMovement(
   event: ResizeEvent,
+  groupId: string,
   handleId: string,
-  { height, width }: Size,
   direction: Direction,
   initialOffset: number
 ): number {
   const isHorizontal = direction === "horizontal";
-  const size = isHorizontal ? width : height;
+
+  const groupElement = getPanelGroup(groupId);
+  const rect = groupElement.getBoundingClientRect();
+  const size = isHorizontal ? rect.width : rect.height;
 
   if (isKeyDown(event)) {
     const denominator = event.shiftKey ? 10 : 100;

--- a/packages/react-resizable-panels/src/utils/group.ts
+++ b/packages/react-resizable-panels/src/utils/group.ts
@@ -1,5 +1,5 @@
 import { PRECISION } from "../constants";
-import { Direction, PanelData } from "../types";
+import { PanelData } from "../types";
 
 export function adjustByDelta(
   panels: Map<string, PanelData>,
@@ -66,33 +66,38 @@ export function adjustByDelta(
   return nextSizes;
 }
 
-export function getOffset(
+// This method returns a number between 1 and 100 representing
+// the % of the group's overall space this panel should occupy.
+export function getFlexGrow(
   panels: Map<string, PanelData>,
   id: string,
-  direction: Direction,
-  sizes: number[],
-  height: number,
-  width: number
-): number {
+  sizes: number[]
+): string {
+  if (panels.size === 1) {
+    return "100";
+  }
+
   const panelsArray = panelsMapToSortedArray(panels);
 
-  let index = panelsArray.findIndex((panel) => panel.id === id);
-  if (index < 0) {
-    return 0;
+  const index = panelsArray.findIndex((panel) => panel.id === id);
+  const size = sizes[index];
+  if (size == null) {
+    return "0";
   }
 
-  let scaledOffset = 0;
-
-  for (index = index - 1; index >= 0; index--) {
-    const panel = panelsArray[index];
-    scaledOffset += getSize(panels, panel.id, direction, sizes, height, width);
-  }
-
-  return Math.round(scaledOffset);
+  return size.toPrecision(PRECISION);
 }
 
 export function getPanel(id: string): HTMLDivElement | null {
   const element = document.querySelector(`[data-panel-id="${id}"]`);
+  if (element) {
+    return element as HTMLDivElement;
+  }
+  return null;
+}
+
+export function getPanelGroup(id: string): HTMLDivElement | null {
+  const element = document.querySelector(`[data-panel-group-id="${id}"]`);
   if (element) {
     return element as HTMLDivElement;
   }
@@ -148,29 +153,4 @@ export function panelsMapToSortedArray(
   panels: Map<string, PanelData>
 ): PanelData[] {
   return Array.from(panels.values()).sort((a, b) => a.order - b.order);
-}
-
-export function getSize(
-  panels: Map<string, PanelData>,
-  id: string,
-  direction: Direction,
-  sizes: number[],
-  height: number,
-  width: number
-): number {
-  const totalSize = direction === "horizontal" ? width : height;
-
-  if (panels.size === 1) {
-    return totalSize;
-  }
-
-  const panelsArray = panelsMapToSortedArray(panels);
-
-  const index = panelsArray.findIndex((panel) => panel.id === id);
-  const size = sizes[index];
-  if (size == null) {
-    return 0;
-  }
-
-  return Math.round(size * totalSize);
 }

--- a/packages/react-resizable-panels/src/utils/serialization.ts
+++ b/packages/react-resizable-panels/src/utils/serialization.ts
@@ -8,8 +8,11 @@ type SerializedPanelGroupState = { [panelIds: string]: number[] };
 // Pre-sorting by minSize allows remembering layouts even if panels are re-ordered/dragged.
 function getSerializationKey(panels: PanelData[]): string {
   return panels
-    .map((panel) => panel.minSize.toPrecision(2))
-    .sort()
+    .map((panel) => {
+      const { minSize, order } = panel;
+      return order ? `${order}:${minSize}` : `${minSize}`;
+    })
+    .sort((a, b) => a.localeCompare(b))
     .join(",");
 }
 


### PR DESCRIPTION
This provides several benefits:
(a) more responsive resizing for nested groups
(b) no explicit width/height prop needed for PanelGroup; can be flex or percentage based
(c) Resize handle components can now be rendered directly within PanelGroups (rather than as children of Panels)

Resolves #30, #32