### PR TITLE
Add [data-resize-handle-active] attribute to resize panels

### DIFF
--- a/packages/react-resizable-panels-website/src/components/ResizeHandle.module.css
+++ b/packages/react-resizable-panels-website/src/components/ResizeHandle.module.css
@@ -1,23 +1,21 @@
-.ResizeHandle {
+.ResizeHandleOuter {
   flex: 0 0 1em;
   position: relative;
   outline: none;
+
+  --background-color: transparent;
+}
+.ResizeHandleOuter[data-resize-handle-active] {
+  --background-color: var(--color-solid-resize-bar-handle);
 }
 
-.ResizeHandleActive,
-.ResizeHandleInactive {
+.ResizeHandleInner {
   position: absolute;
   top: 0.25em;
   bottom: 0.25em;
   left: 0.25em;
   right: 0.25em;
   border-radius: 0.25em;
-  background-color: transparent;
+  background-color: var(--background-color);
   transition: background-color 0.2s linear;
-}
-
-.ResizeHandleActive,
-.ResizeHandle:focus .ResizeHandleInactive,
-.ResizeHandle:hover .ResizeHandleInactive {
-  background-color: var(--color-solid-resize-bar-handle);
 }

--- a/packages/react-resizable-panels-website/src/components/ResizeHandle.tsx
+++ b/packages/react-resizable-panels-website/src/components/ResizeHandle.tsx
@@ -1,5 +1,4 @@
-import { useContext } from "react";
-import { PanelContext, PanelResizeHandle } from "react-resizable-panels";
+import { PanelResizeHandle } from "react-resizable-panels";
 
 import styles from "./ResizeHandle.module.css";
 
@@ -10,19 +9,12 @@ export default function ResizeHandle({
   className?: string;
   id?: string;
 }) {
-  const { activeHandleId } = useContext(PanelContext);
-  const isDragging = activeHandleId === id;
-
   return (
     <PanelResizeHandle
-      className={[styles.ResizeHandle, className].join(" ")}
+      className={[styles.ResizeHandleOuter, className].join(" ")}
       id={id}
     >
-      <div
-        className={
-          isDragging ? styles.ResizeHandleActive : styles.ResizeHandleInactive
-        }
-      />
+      <div className={styles.ResizeHandleInner} />
     </PanelResizeHandle>
   );
 }

--- a/packages/react-resizable-panels-website/tests/ResizeHandle.spec.ts
+++ b/packages/react-resizable-panels-website/tests/ResizeHandle.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+import { verifyAriaValues } from "./utils/aria";
+
+test.describe("Resize handle", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("http://localhost:1234/examples/horizontal");
+  });
+
+  test("should set an 'data-resize-handle-active' attribute when active", async ({
+    page,
+  }) => {
+    const resizeHandle = page.locator("[data-panel-resize-handle-id]").first();
+    await expect(
+      await resizeHandle.getAttribute("data-resize-handle-active")
+    ).toBeNull();
+
+    await resizeHandle.focus();
+    await expect(
+      await resizeHandle.getAttribute("data-resize-handle-active")
+    ).toBe("keyboard");
+
+    await resizeHandle.blur();
+    await expect(
+      await resizeHandle.getAttribute("data-resize-handle-active")
+    ).toBeNull();
+
+    const bounds = await resizeHandle.boundingBox();
+    await page.mouse.move(bounds.x, bounds.y);
+    await page.mouse.down();
+    await expect(
+      await resizeHandle.getAttribute("data-resize-handle-active")
+    ).toBe("pointer");
+
+    await page.mouse.up();
+    await expect(
+      await resizeHandle.getAttribute("data-resize-handle-active")
+    ).toBeNull();
+  });
+});

--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.16 (unreleased)
 * Bug fix: Resize handle ARIA attributes now rendering proper min/max/now values for Window Splitter.
 * Bug fix: Up/down arrows are ignored for _horizontal_ layouts and left/right arrows are ignored for _vertical_ layouts as per Window Splitter spec.
+* [#36](https://github.com/bvaughn/react-resizable-panels/issues/36): Removed `PanelContext` in favor of adding `data-resize-handle-active` attribute to active resize handles. This attribute can be used to update the style for active handles.
 
 ## 0.0.15
 * [#30](https://github.com/bvaughn/react-resizable-panels/issues/30): `PanelGroup` uses `display: flex` rather than absolute positioning. This provides several benefits: (a) more responsive resizing for nested groups, (b) no explicit `width`/`height` props, and (c) `PanelResizeHandle` components can now be rendered directly within `PanelGroup` (rather than as children of `Panel`s).

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -47,8 +47,3 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | `className`   | `?string`    | Class name
 | `disabled`    | `?boolean`   | Disable drag handle
 | `id`          | `?string`    | Optional resize handle id (unique within group); falls back to `useId` when not provided
-
-### `PanelContext`
-| prop         | type                 | description
-| :----------- | :------------------- | :---
-| `activeHandleId` | `string \| null` | Resize handle currently being dragged (or `null`)

--- a/packages/react-resizable-panels/src/PanelContexts.ts
+++ b/packages/react-resizable-panels/src/PanelContexts.ts
@@ -2,11 +2,8 @@ import { CSSProperties, createContext } from "react";
 
 import { PanelData, ResizeEvent, ResizeHandler } from "./types";
 
-export const PanelContext = createContext<{
-  activeHandleId: string | null;
-} | null>(null);
-
 export const PanelGroupContext = createContext<{
+  activeHandleId: string | null;
   direction: "horizontal" | "vertical";
   getPanelStyle: (id: string) => CSSProperties;
   groupId: string;

--- a/packages/react-resizable-panels/src/PanelGroup.tsx
+++ b/packages/react-resizable-panels/src/PanelGroup.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 
-import { PanelContext, PanelGroupContext } from "./PanelContexts";
+import { PanelGroupContext } from "./PanelContexts";
 import { Direction, PanelData, ResizeEvent } from "./types";
 import { loadPanelLayout, savePanelGroupLayout } from "./utils/serialization";
 import { getDragOffset, getMovement } from "./utils/coordinates";
@@ -244,8 +244,9 @@ export default function PanelGroup({
     });
   }, []);
 
-  const panelGroupContext = useMemo(
+  const context = useMemo(
     () => ({
+      activeHandleId,
       direction,
       getPanelStyle,
       groupId,
@@ -262,6 +263,7 @@ export default function PanelGroup({
       unregisterPanel,
     }),
     [
+      activeHandleId,
       direction,
       getPanelStyle,
       groupId,
@@ -269,13 +271,6 @@ export default function PanelGroup({
       registerResizeHandle,
       unregisterPanel,
     ]
-  );
-
-  const panelContext = useMemo(
-    () => ({
-      activeHandleId,
-    }),
-    [activeHandleId]
   );
 
   const style: CSSProperties = {
@@ -286,12 +281,10 @@ export default function PanelGroup({
   };
 
   return (
-    <PanelContext.Provider value={panelContext}>
-      <PanelGroupContext.Provider value={panelGroupContext}>
-        <div className={className} data-panel-group-id={groupId} style={style}>
-          {children}
-        </div>
-      </PanelGroupContext.Provider>
-    </PanelContext.Provider>
+    <PanelGroupContext.Provider value={context}>
+      <div className={className} data-panel-group-id={groupId} style={style}>
+        {children}
+      </div>
+    </PanelGroupContext.Provider>
   );
 }

--- a/packages/react-resizable-panels/src/PanelResizeHandle.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.tsx
@@ -106,7 +106,9 @@ export default function PanelResizeHandle({
   return (
     <div
       className={className}
-      data-resize-handle-active={isDragging || isFocused || undefined}
+      data-resize-handle-active={
+        isDragging ? "pointer" : isFocused ? "keyboard" : undefined
+      }
       data-panel-group-id={groupId}
       data-panel-resize-handle-enabled={!disabled}
       data-panel-resize-handle-id={resizeHandleId}

--- a/packages/react-resizable-panels/src/PanelResizeHandle.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.tsx
@@ -9,7 +9,7 @@ import {
 import useUniqueId from "./hooks/useUniqueId";
 
 import { useWindowSplitterResizeHandlerBehavior } from "./hooks/useWindowSplitterBehavior";
-import { PanelContext, PanelGroupContext } from "./PanelContexts";
+import { PanelGroupContext } from "./PanelContexts";
 import type { ResizeHandler, ResizeEvent } from "./types";
 
 export default function PanelResizeHandle({
@@ -25,16 +25,15 @@ export default function PanelResizeHandle({
 }) {
   const divElementRef = useRef<HTMLDivElement>(null);
 
-  const panelContext = useContext(PanelContext);
   const panelGroupContext = useContext(PanelGroupContext);
-  if (panelContext === null || panelGroupContext === null) {
+  if (panelGroupContext === null) {
     throw Error(
       `PanelResizeHandle components must be rendered within a PanelGroup container`
     );
   }
 
-  const { activeHandleId } = panelContext;
   const {
+    activeHandleId,
     direction,
     groupId,
     registerResizeHandle,
@@ -44,6 +43,8 @@ export default function PanelResizeHandle({
 
   const resizeHandleId = useUniqueId(idFromProps);
   const isDragging = activeHandleId === resizeHandleId;
+
+  const [isFocused, setIsFocused] = useState(false);
 
   const [resizeHandler, setResizeHandler] = useState<ResizeHandler | null>(
     null
@@ -105,9 +106,12 @@ export default function PanelResizeHandle({
   return (
     <div
       className={className}
+      data-resize-handle-active={isDragging || isFocused || undefined}
       data-panel-group-id={groupId}
       data-panel-resize-handle-enabled={!disabled}
       data-panel-resize-handle-id={resizeHandleId}
+      onBlur={() => setIsFocused(false)}
+      onFocus={() => setIsFocused(true)}
       onMouseDown={(event) => startDragging(resizeHandleId, event.nativeEvent)}
       onMouseUp={stopDraggingAndBlur}
       onTouchCancel={stopDraggingAndBlur}

--- a/packages/react-resizable-panels/src/index.ts
+++ b/packages/react-resizable-panels/src/index.ts
@@ -1,6 +1,5 @@
 import Panel from "./Panel";
-import { PanelContext } from "./PanelContexts";
 import PanelGroup from "./PanelGroup";
 import PanelResizeHandle from "./PanelResizeHandle";
 
-export { Panel, PanelContext, PanelGroup, PanelResizeHandle };
+export { Panel, PanelGroup, PanelResizeHandle };


### PR DESCRIPTION
Remove `PanelContext` from public API

Active handle sizing can now be done via `[data-resize-handle-active]` with pure CSS, e.g.:
```css
.ResizeHandleOuter {
  /* Base style */
}
.ResizeHandleOuter[data-resize-handle-active] {
  /* Active style */
}
```

Resolves #36