### PR TITLE
Don't cancel resize operations when exiting the window

### DIFF
--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.0.23
 * [#40](https://github.com/bvaughn/react-resizable-panels/issues/40): Add optional `maxSize` prop to `Panel`.
+* [#42](https://github.com/bvaughn/react-resizable-panels/issues/42): Don't cancel resize operations when exiting the window. Only cancel when a `"mouseup"` (or `"touchend"`) event is fired.
 
 ## 0.0.22
 * Replaced the `"ew-resize"` and `"ns-resize"` cursor style with `"col-resize"` and `"row-resize"`.

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -92,19 +92,19 @@ export default function PanelResizeHandle({
     };
 
     document.body.addEventListener("contextmenu", stopDraggingAndBlur);
-    document.body.addEventListener("mouseleave", stopDraggingAndBlur);
     document.body.addEventListener("mousemove", onMove);
     document.body.addEventListener("touchmove", onMove);
-    document.body.addEventListener("mouseup", stopDraggingAndBlur);
+    window.addEventListener("mouseup", stopDraggingAndBlur);
+    window.addEventListener("touchend", stopDraggingAndBlur);
 
     return () => {
       document.body.style.cursor = "";
 
       document.body.removeEventListener("contextmenu", stopDraggingAndBlur);
-      document.body.removeEventListener("mouseleave", stopDraggingAndBlur);
       document.body.removeEventListener("mousemove", onMove);
       document.body.removeEventListener("touchmove", onMove);
-      document.body.removeEventListener("mouseup", stopDraggingAndBlur);
+      window.removeEventListener("mouseup", stopDraggingAndBlur);
+      window.removeEventListener("touchend", stopDraggingAndBlur);
     };
   }, [direction, disabled, isDragging, resizeHandler, stopDraggingAndBlur]);
 


### PR DESCRIPTION
Only cancel when a `"mouseup"` (or `"touchend"`) event is fired.

Resolves #42