### PR TITLE
Avoid useLayoutEffect server rendering warning

### DIFF
--- a/packages/react-resizable-panels-website/package.json
+++ b/packages/react-resizable-panels-website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "parcel build 'index.html'",
     "test:e2e": "playwright test",
-    "watch": "kill-port 1234 && parcel 'index.html'"
+    "watch": "kill-port ${PORT:-1234} && parcel 'index.html'"
   },
   "devDependencies": {
     "kill-port": "latest"

--- a/packages/react-resizable-panels-website/playwright.config.ts
+++ b/packages/react-resizable-panels-website/playwright.config.ts
@@ -8,8 +8,8 @@ const config: PlaywrightTestConfig = {
     video: "on-first-retry",
   },
   webServer: {
-    command: "npm run watch",
-    url: "http://localhost:1234",
+    command: "PORT=2345 npm run watch",
+    url: "http://localhost:2345",
   },
 };
 

--- a/packages/react-resizable-panels-website/tests/OnResize.spec.ts
+++ b/packages/react-resizable-panels-website/tests/OnResize.spec.ts
@@ -22,7 +22,7 @@ async function verifySizes(
 
 test.describe("onResize prop", () => {
   test("should call onResize when panels are resized", async ({ page }) => {
-    await page.goto("http://localhost:1234/examples/external-persistence");
+    await page.goto("http://localhost:2345/examples/external-persistence");
 
     const resizeHandles = page.locator("[data-panel-resize-handle-id]");
     const first = resizeHandles.first();

--- a/packages/react-resizable-panels-website/tests/utils/url.ts
+++ b/packages/react-resizable-panels-website/tests/utils/url.ts
@@ -8,7 +8,7 @@ export async function goToUrl(
   element: ReactElement<PanelGroupProps>
 ) {
   const encodedString = UrlPanelGroupToEncodedString(element);
-  const url = `http://localhost:1234/__e2e?urlPanelGroup=${encodedString}`;
+  const url = `http://localhost:2345/__e2e?urlPanelGroup=${encodedString}`;
 
   await page.goto(url);
 }

--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 0.0.28
+* [#53](https://github.com/bvaughn/react-resizable-panels/issues/53): Avoid `useLayoutEffect` warning when server rendering. Render panels with default style of `flex: 1 1 auto` during initial render.
 
 ## 0.0.27
 * [#4](https://github.com/bvaughn/react-resizable-panels/issues/4): Add `collapsible` and `onCollapse` props to `Panel` to support auto-collapsing panels that resize beyond their `minSize` value (similar to VS Code's panel UX).

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -5,9 +5,9 @@ import {
   ReactNode,
   useContext,
   useEffect,
-  useLayoutEffect,
   useRef,
 } from "react";
+import useIsomorphicLayoutEffect from "./hooks/useIsomorphicEffect";
 import useUniqueId from "./hooks/useUniqueId";
 
 import { PanelGroupContext } from "./PanelContexts";
@@ -84,7 +84,7 @@ export default function Panel({
 
   const { getPanelStyle, registerPanel, unregisterPanel } = context;
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const panel = {
       callbacksRef,
       collapsible,

--- a/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts
+++ b/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts
@@ -1,0 +1,6 @@
+import { useEffect, useLayoutEffect } from "react";
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
Resolves #53

### Initial render

<img width="991" alt="Screen Shot 2023-01-02 at 5 48 49 PM" src="https://user-images.githubusercontent.com/29597/210283320-7c65bb8b-cd7b-438e-8932-daf519a44a3b.png">

### Second render
<img width="987" alt="Screen Shot 2023-01-02 at 5 49 07 PM" src="https://user-images.githubusercontent.com/29597/210283321-8a5e9045-e009-43f5-b290-b046a8fc1700.png">

Note that the initial render above will never be visible to a user because `PanelGroup` will re-render via a layout effect _before_ the browser paints: