### PR TITLE
fix: update server check to use document

### DIFF
--- a/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts
+++ b/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts
@@ -1,6 +1,13 @@
 import { useEffect, useLayoutEffect } from "react";
 
-const useIsomorphicLayoutEffect =
-  typeof document !== "undefined" ? useLayoutEffect : useEffect;
+const canUseEffectHooks = !!(
+  typeof window !== "undefined" &&
+  typeof window.document !== "undefined" &&
+  typeof window.document.createElement !== "undefined"
+);
+
+const useIsomorphicLayoutEffect = canUseEffectHooks
+  ? useLayoutEffect
+  : () => {};
 
 export default useIsomorphicLayoutEffect;

--- a/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts
+++ b/packages/react-resizable-panels/src/hooks/useIsomorphicEffect.ts
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect } from "react";
 
 const useIsomorphicLayoutEffect =
-  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+  typeof document !== "undefined" ? useLayoutEffect : useEffect;
 
 export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
Server runtimes such as Deno have `window` global, but they should still use `useEffect` and not `useLayoutEffect`. `document` is a better way to check if it is a server runtime or browser