### PR TITLE
Adds copy button

### DIFF
--- a/packages/react-resizable-panels-website/src/components/Code.tsx
+++ b/packages/react-resizable-panels-website/src/components/Code.tsx
@@ -6,6 +6,7 @@ import {
   parsedTokensToHtml,
 } from "../suspense/SyntaxParsingCache";
 import { ParsedTokens } from "../suspense/SyntaxParsingCache";
+import Copy from "./Copy";
 
 import styles from "./Code.module.css";
 
@@ -14,11 +15,13 @@ export default function Code({
   code,
   language = "jsx",
   showLineNumbers = false,
+  copyHidden = false,
 }: {
   className?: string;
   code: string;
   language: Language;
   showLineNumbers?: boolean;
+  copyHidden?: boolean;
 }) {
   return (
     <Suspense>
@@ -27,6 +30,7 @@ export default function Code({
         code={code}
         language={language}
         showLineNumbers={showLineNumbers}
+        copyHidden={copyHidden}
       />
     </Suspense>
   );
@@ -37,11 +41,13 @@ function Parser({
   code,
   language,
   showLineNumbers,
+  copyHidden = false,
 }: {
   className: string;
   code: string;
   language: Language;
   showLineNumbers: boolean;
+  copyHidden?: boolean;
 }) {
   const tokens = parse(code, language);
   return (
@@ -49,6 +55,8 @@ function Parser({
       className={className}
       tokens={tokens}
       showLineNumbers={showLineNumbers}
+      code={code}
+      copyHidden={copyHidden}
     />
   );
 }
@@ -57,10 +65,14 @@ function TokenRenderer({
   className,
   showLineNumbers,
   tokens,
+  code,
+  copyHidden = false,
 }: {
   className?: string;
   showLineNumbers: boolean;
   tokens: ParsedTokens[];
+  code: string;
+  copyHidden?: boolean;
 }) {
   const maxLineNumberLength = `${tokens.length + 1}`.length;
 
@@ -81,13 +93,15 @@ function TokenRenderer({
   }, [showLineNumbers, tokens]);
 
   return (
-    <code
-      className={[styles.Code, className].join(" ")}
+    <>
+      <Copy code={code} hidden={copyHidden} />
+      <code
+      className={[styles.Code, 'code', className].join(" ")}
       dangerouslySetInnerHTML={{ __html: html }}
       style={{
         // @ts-ignore
-        "--max-line-number-length": `${maxLineNumberLength}ch`,
-      }}
-    />
+        "--max-line-number-length": `${maxLineNumberLength}ch`
+      }}/>
+    </>
   );
 }

--- a/packages/react-resizable-panels-website/src/components/Copy.module.css
+++ b/packages/react-resizable-panels-website/src/components/Copy.module.css
@@ -1,0 +1,30 @@
+.Copy {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  float: right;
+  margin-top: 0.5rem;
+  margin-right: 0.5rem;
+  background-color: var(--color-button-background);
+  color: #fff;
+  border-color: transparent;
+  border-radius: 0.5rem;
+}
+
+/* temporary fix for making it look right with the overflow panels */
+div[class*="Centered"] > button {
+  display: none;
+}
+
+.Copy:hover {
+  background-color: var(--color-button-background-hover);
+}
+
+.Copy svg {
+  fill: #fff;
+}
+
+.Copy span {
+  font-size: 1rem;
+  word-break: keep-all;
+}

--- a/packages/react-resizable-panels-website/src/components/Copy.module.css
+++ b/packages/react-resizable-panels-website/src/components/Copy.module.css
@@ -17,6 +17,7 @@ div[class*="Centered"] > button {
 }
 
 .Copy:hover {
+  cursor: pointer;
   background-color: var(--color-button-background-hover);
 }
 

--- a/packages/react-resizable-panels-website/src/components/Copy.tsx
+++ b/packages/react-resizable-panels-website/src/components/Copy.tsx
@@ -1,0 +1,33 @@
+import styles from "./Copy.module.css";
+
+export default function Copy({
+  className = "",
+  code,
+  hidden = false,
+}: {
+  className?: string;
+  code: string;
+  hidden?: boolean;
+}) {
+    if (hidden) {
+        return null;
+    }
+
+  return (
+    <button className={[styles.Copy, className].join(" ")} onClick={
+        () => {
+            navigator.clipboard.writeText(code).then(function() {
+                document.getElementById('copyLabel').innerText = 'Copied!';
+                setTimeout(function(){
+                    document.getElementById('copyLabel').innerText = 'Copy';
+                }, 3000);
+            }, function(err) {
+                console.error('Copy error: ', err);
+            })
+        }
+    }>
+        <svg xmlns="http://www.w3.org/2000/svg" height="14" width="14" viewBox="0 0 48 48"><path d="M8.75 45.15q-1.6 0-2.775-1.175Q4.8 42.8 4.8 41.2V11.3h3.95v29.9H32.2v3.95Zm7-6.95q-1.65 0-2.825-1.175Q11.75 35.85 11.75 34.2V6.7q0-1.6 1.175-2.775Q14.1 2.75 15.75 2.75h21.5q1.6 0 2.775 1.175Q41.2 5.1 41.2 6.7v27.5q0 1.65-1.175 2.825Q38.85 38.2 37.25 38.2Zm0-4h21.5V6.7h-21.5v27.5Zm0 0V6.7v27.5Z"/></svg>
+        <span id="copyLabel">Copy</span>
+    </button>
+  );
+}

--- a/packages/react-resizable-panels-website/src/routes/examples/Collapsible/index.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Collapsible/index.tsx
@@ -112,6 +112,7 @@ function Content() {
             code={currentFile.code.trim()}
             language={currentFile.language}
             showLineNumbers
+            copyHidden
           />
         </Panel>
       </PanelGroup>


### PR DESCRIPTION
Adds a copy button to the code snippets on the website. 

Closes #60 

Known issue: Because of how the overflow blocks work and the Code component builds the lines, I've been unable to find a good solution for integrating the button without refactoring the whole Code component. The copy button is hidden on the overflow panels as a temporary fix. 