### PR TITLE
PanelGroup: debounce localStorage writes and add onResized prop

### DIFF
--- a/packages/react-resizable-panels-website/root.css
+++ b/packages/react-resizable-panels-website/root.css
@@ -18,6 +18,7 @@
   --color-panel-background-alternate: #202124;
   --color-solid-resize-bar: #39414d;
   --color-scroll-thumb: #39414d;
+  --color-warning-background: #7400cc;
 
   --color-logo-background: #2a3343;
   --color-logo-chip-1: #dcadff;

--- a/packages/react-resizable-panels-website/src/hooks/useDebouncedCallback.ts
+++ b/packages/react-resizable-panels-website/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,26 @@
+import { useLayoutEffect, useMemo, useRef } from "react";
+
+export default function useDebouncedCallback<A extends any[]>(
+  callback: (...args: A) => void,
+  delayMs: number = 100
+) {
+  const callbackRef = useRef<(...args: A) => void>(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  const memoizedCallback = useMemo(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    return (...args: any) => {
+      clearTimeout(timeoutId);
+
+      timeoutId = setTimeout(() => {
+        const callback = callbackRef.current;
+        callback(...args);
+      }, delayMs);
+    };
+  }, [delayMs]);
+
+  return memoizedCallback;
+}

--- a/packages/react-resizable-panels-website/src/routes/examples/ExternalPersistence.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/ExternalPersistence.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
 
 import ResizeHandle from "../../components/ResizeHandle";
+import useDebouncedCallback from "../../hooks/useDebouncedCallback";
 
 import Example from "./Example";
 import styles from "./shared.module.css";
@@ -18,11 +19,12 @@ export default function ExternalPersistence() {
             layouts using <code>localStorage</code>. This example shows how the{" "}
             <code>defaultSize</code> and <code>onResize</code> props can be used
             to persist layouts somewhere custom/external. In this case, sizes
-            are saved as part of the URL hash.
+            are saved as part of the URL hash after a debounce duration of{" "}
+            <strong>500ms</strong>.
           </p>
-          <p>
-            Note that when the <code>onResize</code> prop is used, the
-            <code>order</code> prop should also be specified.
+          <p className={styles.WarningBlock}>
+            ⚠ Note that when the <code>onResize</code> prop is used, the
+            <code>order</code> prop must also be provided.
           </p>
         </>
       }
@@ -62,13 +64,26 @@ function Content() {
     }));
   };
 
-  useEffect(() => {
-    window.location.hash = encodeURI(JSON.stringify(sizes));
-  }, [sizes]);
+  const onLayout = useDebouncedCallback((sizesArray: number[]) => {
+    const sizesObject: Sizes = {
+      left: sizesArray[0],
+      middle: sizesArray[1],
+      right: sizesArray[2],
+    };
+
+    const encoded = encodeURI(JSON.stringify(sizesObject));
+
+    // Update the hash without interfering with the browser's Back button.
+    history.replaceState(undefined, undefined, `#${encoded}`);
+  }, 500);
 
   return (
     <div className={styles.PanelGroupWrapper}>
-      <PanelGroup className={styles.PanelGroup} direction="horizontal">
+      <PanelGroup
+        className={styles.PanelGroup}
+        direction="horizontal"
+        onLayout={onLayout}
+      >
         <Panel
           className={styles.PanelRow}
           collapsible={true}

--- a/packages/react-resizable-panels-website/src/routes/examples/shared.module.css
+++ b/packages/react-resizable-panels-website/src/routes/examples/shared.module.css
@@ -98,3 +98,10 @@
 .Capitalize {
   text-transform: capitalize;
 }
+
+.WarningBlock {
+  display: inline-block;
+  background: var(--color-warning-background);
+  padding: 0.25em 1ch;
+  border-radius: 0.5rem;
+}

--- a/packages/react-resizable-panels-website/tests/LocalStorage.spec.ts
+++ b/packages/react-resizable-panels-website/tests/LocalStorage.spec.ts
@@ -64,6 +64,9 @@ test.describe("localStorage", () => {
       now: 70,
     });
 
+    // Wait for localStorage write debounce
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
     // Values should be remembered after a page reload
     await page.reload();
     await verifyAriaValues(first, {
@@ -90,6 +93,9 @@ test.describe("localStorage", () => {
       now: 33,
     });
 
+    // Wait for localStorage write debounce
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
     // Hide the first panel and then resize things
     await goToUrl(page, panelGroupBC);
     await first.focus();
@@ -97,6 +103,9 @@ test.describe("localStorage", () => {
     await verifyAriaValues(first, {
       now: 10,
     });
+
+    // Wait for localStorage write debounce
+    await new Promise((resolve) => setTimeout(resolve, 250));
 
     // Hide the last panel and then resize things
     await goToUrl(page, panelGroupAB);
@@ -106,8 +115,10 @@ test.describe("localStorage", () => {
       now: 90,
     });
 
-    // Reload and verify all of the different layouts are remembered individually
+    // Wait for localStorage write debounce
+    await new Promise((resolve) => setTimeout(resolve, 250));
 
+    // Reload and verify all of the different layouts are remembered individually
     await goToUrl(page, panelGroupABC);
     await verifyAriaValues(first, {
       now: 33,

--- a/packages/react-resizable-panels-website/tests/OnLayout.spec.ts
+++ b/packages/react-resizable-panels-website/tests/OnLayout.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("PanelGroup onLayout prop", () => {
+  test("should call onLayout when group is resized", async ({ page }) => {
+    await page.goto("http://localhost:2345/examples/external-persistence");
+
+    const resizeHandles = page.locator("[data-panel-resize-handle-id]");
+    const first = resizeHandles.first();
+    const last = resizeHandles.last();
+
+    await first.focus();
+    await page.keyboard.press("Home");
+    await last.focus();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Shift+ArrowLeft");
+
+    // Wait for test harness debounce
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+    const expectedSizes = {
+      left: 0,
+      middle: 90,
+      right: 10,
+    };
+
+    expect(page.url()).toContain(
+      "#" + encodeURI(JSON.stringify(expectedSizes))
+    );
+  });
+});

--- a/packages/react-resizable-panels-website/tests/OnResize.spec.ts
+++ b/packages/react-resizable-panels-website/tests/OnResize.spec.ts
@@ -18,7 +18,7 @@ async function verifySizes(
   );
 }
 
-test.describe("onResize prop", () => {
+test.describe("Panel onResize prop", () => {
   test("should call onResize when panels are resized", async ({ page }) => {
     await page.goto("http://localhost:2345/examples/external-persistence");
 

--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.30
+* [#68](https://github.com/bvaughn/react-resizable-panels/pull/68): Reduce volume/frequency of local storage writes for `PanelGroup`s configured to _auto-save_.
+* Added `onLayout` prop to `PanelGroup` to be called when group layout changes. Note that some form of debouncing is recommended before processing these values (e.g. saving to a database).
+
 ## 0.0.29
 * [#58](https://github.com/bvaughn/react-resizable-panels/pull/58): Add imperative `collapse`, `expand`, and `resize` methods to `Panel`.
 * [#64](https://github.com/bvaughn/react-resizable-panels/pull/64): Disable `pointer-events` inside of `Panel`s during resize. This avoid edge cases like nested iframes.

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -26,27 +26,28 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | :----------- | :-------------------------- | :---
 | `autoSaveId` | `?string`                   | Unique id used to auto-save group arrangement via `localStorage`
 | `children`   | `ReactNode`                 | Arbitrary React element(s)
-| `className`  | `?string`                   | Optional class name to attach to root element
+| `className`  | `?string`                   | Class name to attach to root element
 | `direction`  | `"horizontal" \| "vertical"` | Group orientation
-| `id`         | `?string`                   | Optional group id; falls back to `useId` when not provided
-| `style`      | `?CSSProperties`            | Optional CSS style to attach to root element
-| `tagName`    | `?string = "div"`           | Optional HTML element tag name for root element
+| `id`         | `?string`                   | Group id; falls back to `useId` when not provided
+| `onLayout`  | `?(sizes: number[]) => void` | Called when group layout changes
+| `style`      | `?CSSProperties`            | CSS style to attach to root element
+| `tagName`    | `?string = "div"`           | HTML element tag name for root element
 
 ### `Panel`
 | prop          | type                            | description
 | :------------ | :------------------------------ | :---
 | `children`    | `ReactNode`                     | Arbitrary React element(s)
-| `className`   | `?string`                       | Optional class name to attach to root element
+| `className`   | `?string`                       | Class name to attach to root element
 | `collapsible` | `?boolean=false`                | Panel should collapse when resized beyond its `minSize`
 | `defaultSize` | `?number`                       | Initial size of panel (numeric value between 1-100)
-| `id`          | `?string`                       | Optional panel id (unique within group); falls back to `useId` when not provided
+| `id`          | `?string`                       | Panel id (unique within group); falls back to `useId` when not provided
 | `maxSize`     | `?number = 100`                 | Maximum allowable size of panel (numeric value between 1-100); defaults to `100`
 | `minSize`     | `?number = 10`                  | Minimum allowable size of panel (numeric value between 1-100); defaults to `10`
-| `onCollapse`  | `?(collapsed: boolean) => void` | Optional function to be called when panel is collapsed; `collapsed` boolean parameter reflecting the new state
-| `onResize`    | `?(size: number) => void`       | Optional function to be called when panel is resized; `size` parameter is a numeric value between 1-100
+| `onCollapse`  | `?(collapsed: boolean) => void` | Called when panel is collapsed; `collapsed` boolean parameter reflecting the new state
+| `onResize`    | `?(size: number) => void`       | Called when panel is resized; `size` parameter is a numeric value between 1-100
 | `order`       | `?number`                       | Order of panel within group; required for groups with conditionally rendered panels
-| `style`       | `?CSSProperties`                | Optional CSS style to attach to root element
-| `tagName`     | `?string = "div"`               | Optional HTML element tag name for root element
+| `style`       | `?CSSProperties`                | CSS style to attach to root element
+| `tagName`     | `?string = "div"`               | HTML element tag name for root element
 
 `Panel` components also expose an imperative API for manual resizing:
 | method                       | description
@@ -55,13 +56,12 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 | `expand`                     | If panel is currently _collapsed_, expand it to its most recent size.
 | `resize(percentage: number)` | Resize panel to the specified _percentage_ (`1 - 100`).
 
-
 ### `PanelResizeHandle`
 | prop          | type              | description
 | :------------ | :---------------- | :---
 | `children`    | `?ReactNode`      | Custom drag UI; can be any arbitrary React element(s)
-| `className`   | `?string`         | Optional class name to attach to root element
+| `className`   | `?string`         | Class name to attach to root element
 | `disabled`    | `?boolean`        | Disable drag handle
-| `id`          | `?string`         | Optional resize handle id (unique within group); falls back to `useId` when not provided
-| `style`       | `?CSSProperties`  | Optional CSS style to attach to root element
-| `tagName`     | `?string = "div"` | Optional HTML element tag name for root element
+| `id`          | `?string`         | Resize handle id (unique within group); falls back to `useId` when not provided
+| `style`       | `?CSSProperties`  | CSS style to attach to root element
+| `tagName`     | `?string = "div"` | HTML element tag name for root element

--- a/packages/react-resizable-panels/src/types.ts
+++ b/packages/react-resizable-panels/src/types.ts
@@ -2,6 +2,7 @@ import { RefObject } from "react";
 
 export type Direction = "horizontal" | "vertical";
 
+export type PanelGroupOnLayout = (sizes: number[]) => void;
 export type PanelOnCollapse = (collapsed: boolean) => void;
 export type PanelOnResize = (size: number) => void;
 

--- a/packages/react-resizable-panels/src/utils/debounce.ts
+++ b/packages/react-resizable-panels/src/utils/debounce.ts
@@ -1,0 +1,16 @@
+export default function debounce<T extends Function>(
+  callback: T,
+  durationMs: number = 10
+) {
+  let timeoutId: NodeJS.Timeout | null = null;
+
+  let callable = (...args: any) => {
+    clearTimeout(timeoutId);
+
+    timeoutId = setTimeout(() => {
+      callback(...args);
+    }, durationMs);
+  };
+
+  return callable as unknown as T;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "es2020",
     "moduleResolution": "node",
     "noImplicitAny": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["node"]
   },
   "exclude": ["node_modules"],
   "include": ["declaration.d.ts", "packages/**/*.ts", "packages/**/*.tsx"],


### PR DESCRIPTION
Also update External persistence test harness to debounce URL writes and not override browser location history.

Resolves #68