### PR TITLE
Layout changes triggered by keyboard no longer affect the global cursor

### DIFF
--- a/packages/react-resizable-panels-website/tests/CursorStyle.spec.ts
+++ b/packages/react-resizable-panels-website/tests/CursorStyle.spec.ts
@@ -27,7 +27,7 @@ test.describe("cursor style", () => {
 
     await handle.focus();
     await page.keyboard.press("ArrowLeft");
-    await expect(await body.evaluate(getCursorStyle)).toBe("col-resize");
+    await expect(await body.evaluate(getCursorStyle)).toBe("auto");
 
     await page.keyboard.press("Shift+Tab");
     await expect(await body.evaluate(getCursorStyle)).toBe("auto");

--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.0.34
 * [#70](https://github.com/bvaughn/react-resizable-panels/issues/70): When resizing is done via mouse/touch event– some initial state is stored so that any panels that contract will also expand if drag direction is reversed.
+* [#86](https://github.com/bvaughn/react-resizable-panels/issues/86): Layout changes triggered by keyboard no longer affect the global cursor.
+* Fixed small cursor regression introduced in 0.0.33.
 
 ## 0.0.33
 * Collapsible `Panel`s will always call `onCollapse` on-mount regardless of their collapsed state.

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -346,23 +346,29 @@ export function PanelGroup({
           baseSizes,
           panelSizeBeforeCollapse.current
         );
-        if (prevSizes === nextSizes) {
-          // If the pointer has moved too far to resize the panel any further,
-          // update the cursor style for a visual clue.
-          // This mimics VS Code behavior.
-          if (isHorizontal) {
-            setGlobalCursorStyle(
-              movement < 0 ? "horizontal-min" : "horizontal-max"
-            );
-          } else {
-            setGlobalCursorStyle(
-              movement < 0 ? "vertical-min" : "vertical-max"
-            );
-          }
-        } else {
-          // Reset the cursor style to the the normal resize cursor.
-          setGlobalCursorStyle(isHorizontal ? "horizontal" : "vertical");
 
+        if (isMouseEvent(event) || isTouchEvent(event)) {
+          if (prevSizes === nextSizes) {
+            // If the pointer has moved too far to resize the panel any further,
+            // update the cursor style for a visual clue.
+            // This mimics VS Code behavior.
+
+            if (isHorizontal) {
+              setGlobalCursorStyle(
+                movement < 0 ? "horizontal-min" : "horizontal-max"
+              );
+            } else {
+              setGlobalCursorStyle(
+                movement < 0 ? "vertical-min" : "vertical-max"
+              );
+            }
+          } else {
+            // Reset the cursor style to the the normal resize cursor.
+            setGlobalCursorStyle(isHorizontal ? "horizontal" : "vertical");
+          }
+        }
+
+        if (prevSizes !== nextSizes) {
           // If resize change handlers have been declared, this is the time to call them.
           callPanelCallbacks(panelsArray, prevSizes, nextSizes);
 

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -16,7 +16,7 @@ import useUniqueId from "./hooks/useUniqueId";
 import { useWindowSplitterResizeHandlerBehavior } from "./hooks/useWindowSplitterBehavior";
 import { PanelGroupContext } from "./PanelContexts";
 import type { ResizeHandler, ResizeEvent } from "./types";
-import { getCursorStyle, resetGlobalCursorStyle } from "./utils/cursor";
+import { getCursorStyle } from "./utils/cursor";
 
 export type PanelResizeHandleProps = {
   children?: ReactNode;
@@ -128,10 +128,7 @@ export function PanelResizeHandle({
     "data-panel-group-id": groupId,
     "data-panel-resize-handle-enabled": !disabled,
     "data-panel-resize-handle-id": resizeHandleId,
-    onBlur: () => {
-      setIsFocused(false);
-      resetGlobalCursorStyle();
-    },
+    onBlur: () => setIsFocused(false),
     onFocus: () => setIsFocused(true),
     onMouseDown: (event: MouseEvent) =>
       startDragging(resizeHandleId, event.nativeEvent),

--- a/packages/react-resizable-panels/src/utils/arrays.ts
+++ b/packages/react-resizable-panels/src/utils/arrays.ts
@@ -1,0 +1,13 @@
+export function areEqual(arrayA: any[], arrayB: any[]): boolean {
+  if (arrayA.length !== arrayB.length) {
+    return false;
+  }
+
+  for (let index = 0; index < arrayA.length; index++) {
+    if (arrayA[index] !== arrayB[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/react-resizable-panels/src/utils/coordinates.ts
+++ b/packages/react-resizable-panels/src/utils/coordinates.ts
@@ -1,4 +1,5 @@
 import { PRECISION } from "../constants";
+import { InitialDragState } from "../PanelGroup";
 import { Direction, PanelData, ResizeEvent } from "../types";
 import {
   getPanelGroup,
@@ -50,10 +51,19 @@ export function getMovement(
   handleId: string,
   panelsArray: PanelData[],
   direction: Direction,
-  sizes: number[],
-  initialOffset: number,
-  initialHandleElementRect: DOMRect | null = null
+  prevSizes: number[],
+  initialDragState: InitialDragState | null
 ): number {
+  const {
+    dragOffset = 0,
+    dragHandleRect,
+    sizes: initialSizes,
+  } = initialDragState || {};
+
+  // If we're resizing by mouse or touch, use the initial sizes as a base.
+  // This has the benefit of causing force-collapsed panels to spring back open if drag is reversed.
+  const baseSizes = initialSizes || prevSizes;
+
   if (isKeyDown(event)) {
     const isHorizontal = direction === "horizontal";
 
@@ -101,10 +111,10 @@ export function getMovement(
     );
     const targetPanel = panelsArray[targetPanelIndex];
     if (targetPanel.collapsible) {
-      const prevSize = sizes[targetPanelIndex];
+      const baseSize = baseSizes[targetPanelIndex];
       if (
-        prevSize === 0 ||
-        prevSize.toPrecision(PRECISION) ===
+        baseSize === 0 ||
+        baseSize.toPrecision(PRECISION) ===
           targetPanel.minSize.toPrecision(PRECISION)
       ) {
         movement =
@@ -120,8 +130,8 @@ export function getMovement(
       event,
       handleId,
       direction,
-      initialOffset,
-      initialHandleElementRect
+      dragOffset,
+      dragHandleRect
     );
   }
 }


### PR DESCRIPTION
Builds on top of PR #87. Resolves #86.

- [x] Layout changes triggered by keyboard no longer affect the global cursor.
- [x] Fixed small cursor regression introduced in 0.0.33.