### PR TITLE
set browerslist to 'Chrome 79'

### DIFF
--- a/packages/react-resizable-panels/package.json
+++ b/packages/react-resizable-panels/package.json
@@ -23,5 +23,8 @@
   "peerDependencies": {
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
-  }
+  },
+  "browserslist": [
+    "Chrome 79"
+  ]
 }


### PR DESCRIPTION
By setting the browserlist to 'Chrome 79', Parcel produces Javascript that can be parsed with the Babel version available in CRA 4.0.3. This addresses problems with optional chaining, which is available starting with Chrome 80 (see https://caniuse.com/mdn-javascript_operators_optional_chaining)

See also https://github.com/bvaughn/react-resizable-panels/issues/72