### PR TITLE
Removed useId import that is not compatible with React < 18

### DIFF
--- a/packages/react-resizable-panels/src/hooks/useUniqueId.ts
+++ b/packages/react-resizable-panels/src/hooks/useUniqueId.ts
@@ -1,13 +1,11 @@
-import { useId, useRef } from "react";
+import { useRef } from "react";
 
 let counter = 0;
 
 export default function useUniqueId(
   idFromParams: string | null = null
 ): string {
-  const idFromUseId = typeof useId === "function" ? useId() : null;
-
-  const idRef = useRef<string | null>(idFromParams || idFromUseId || null);
+  const idRef = useRef<string | null>(idFromParams || null);
   if (idRef.current === null) {
     idRef.current = "" + counter++;
   }


### PR DESCRIPTION
When using React versions under 18, useId is not exported by React which causes this error

`export 'useId' (imported as '$jhddX$useId') was not found in 'react'`

This pull removes the dependency on useId