### PR TITLE
No longer disable 'pointer-events' during resize by default

### DIFF
--- a/packages/react-resizable-panels/CHANGELOG.md
+++ b/packages/react-resizable-panels/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.36
+* [#96](https://github.com/bvaughn/react-resizable-panels/issues/96): No longer disable `pointer-events` during resize by default. This behavior can be re-enabled using the newly added `PanelGroup` prop `disablePointerEventsDuringResize`.
+
 ## 0.0.35
 * [#92](https://github.com/bvaughn/react-resizable-panels/pull/92): Change `browserslist` so compiled module works with CRA 4.0.3 Babel config out of the box.
 ## 0.0.34

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -22,21 +22,24 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 ## Props
 
 ### `PanelGroup`
-| prop         | type                        | description
-| :----------- | :-------------------------- | :---
-| `autoSaveId` | `?string`                   | Unique id used to auto-save group arrangement via `localStorage`
-| `children`   | `ReactNode`                 | Arbitrary React element(s)
-| `className`  | `?string`                   | Class name to attach to root element
-| `direction`  | `"horizontal" \| "vertical"` | Group orientation
-| `id`         | `?string`                   | Group id; falls back to `useId` when not provided
-| `onLayout`  | `?(sizes: number[]) => void` | Called when group layout changes
-| `storage`    | `?PanelGroupStorage`        | Custom storage API; defaults to `localStorage` <sup>1</sup>
-| `style`      | `?CSSProperties`            | CSS style to attach to root element
-| `tagName`    | `?string = "div"`           | HTML element tag name for root element
+| prop                               | type                        | description
+| :--------------------------------- | :-------------------------- | :---
+| `autoSaveId`                       | `?string`                   | Unique id used to auto-save group arrangement via `localStorage`
+| `children`                         | `ReactNode`                 | Arbitrary React element(s)
+| `className`                        | `?string`                   | Class name to attach to root element
+| `direction`                        | `"horizontal" \| "vertical"` | Group orientation
+| `disablePointerEventsDuringResize` | `?boolean = false`          | Disable pointer events inside `Panel`s during resize <sup>2</sup>
+| `id`                               | `?string`                   | Group id; falls back to `useId` when not provided
+| `onLayout`                        | `?(sizes: number[]) => void` | Called when group layout changes
+| `storage`                          | `?PanelGroupStorage`        | Custom storage API; defaults to `localStorage` <sup>1</sup>
+| `style`                            | `?CSSProperties`            | CSS style to attach to root element
+| `tagName`                          | `?string = "div"`           | HTML element tag name for root element
 
 <sup>1</sup>: Storage API must define the following _synchronous_ methods:
 * `getItem: (name:string) => string`
 * `setItem: (name: string, value: string) => void`
+
+ <sup>2</sup>: This behavior is disabled by default because it can interfere with scrollbar styles, but it can be useful in the edge case where a `Panel` contains an `<iframe>`
 
 ### `Panel`
 | prop          | type                            | description

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -90,6 +90,7 @@ export type PanelGroupProps = {
   children?: ReactNode;
   className?: string;
   direction: Direction;
+  disablePointerEventsDuringResize?: boolean;
   id?: string | null;
   onLayout?: PanelGroupOnLayout;
   storage?: PanelGroupStorage;
@@ -102,6 +103,7 @@ export function PanelGroup({
   children = null,
   className: classNameFromProps = "",
   direction,
+  disablePointerEventsDuringResize = false,
   id: idFromProps = null,
   onLayout = null,
   storage = defaultStorage,
@@ -293,7 +295,10 @@ export function PanelGroup({
 
         // Disable pointer events inside of a panel during resize.
         // This avoid edge cases like nested iframes.
-        pointerEvents: activeHandleId !== null ? "none" : undefined,
+        pointerEvents:
+          disablePointerEventsDuringResize && activeHandleId !== null
+            ? "none"
+            : undefined,
       };
     },
     [activeHandleId, direction, sizes]


### PR DESCRIPTION
This behavior can be re-enabled using the newly added 'PanelGroup' prop 'disablePointerEventsDuringResize'.