### PR TITLE
add DOCTYPE declaration to the example website

### DIFF
--- a/packages/react-resizable-panels-website/index.html
+++ b/packages/react-resizable-panels-website/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <html>
     <head>


### PR DESCRIPTION
Prevents browser from switching to [Quirks mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode)

Ref: https://github.com/bvaughn/react-resizable-panels/issues/99