### PR TITLE
Issue/103

### DIFF
--- a/packages/react-resizable-panels-website/src/routes/EndToEndTesting/index.tsx
+++ b/packages/react-resizable-panels-website/src/routes/EndToEndTesting/index.tsx
@@ -18,7 +18,6 @@ export default function EndToEndTesting() {
   const [size, setSize] = useState(0);
   const [checked, setChecked] = useState(false);
 
-
   const debugLogRef = useRef<ImperativeDebugLogHandle>(null);
   const idToPanelMapRef = useRef<Map<string, ImperativePanelHandle>>(new Map());
 
@@ -40,7 +39,7 @@ export default function EndToEndTesting() {
     const idToPanelMap = idToPanelMapRef.current;
     const panel = idToPanelMap.get(panelId);
     if (panel) {
-      panel.collapse(checked ? 'before': 'after');
+      panel.collapse(checked ? "before" : "after");
     }
   };
 
@@ -48,7 +47,7 @@ export default function EndToEndTesting() {
     const idToPanelMap = idToPanelMapRef.current;
     const panel = idToPanelMap.get(panelId);
     if (panel) {
-      panel.expand(checked ? 'before': 'after');
+      panel.expand(checked ? "before" : "after");
     }
   };
 
@@ -89,7 +88,7 @@ export default function EndToEndTesting() {
           <input
             id="direction"
             checked={checked}
-            onChange={event => setChecked(event.target.checked)}
+            onChange={(event) => setChecked(event.target.checked)}
             type="checkbox"
           />
         </label>

--- a/packages/react-resizable-panels-website/src/routes/EndToEndTesting/index.tsx
+++ b/packages/react-resizable-panels-website/src/routes/EndToEndTesting/index.tsx
@@ -16,6 +16,8 @@ export default function EndToEndTesting() {
 
   const [panelId, setPanelId] = useState("");
   const [size, setSize] = useState(0);
+  const [checked, setChecked] = useState(false);
+
 
   const debugLogRef = useRef<ImperativeDebugLogHandle>(null);
   const idToPanelMapRef = useRef<Map<string, ImperativePanelHandle>>(new Map());
@@ -38,7 +40,7 @@ export default function EndToEndTesting() {
     const idToPanelMap = idToPanelMapRef.current;
     const panel = idToPanelMap.get(panelId);
     if (panel) {
-      panel.collapse();
+      panel.collapse(checked ? 'before': 'after');
     }
   };
 
@@ -46,7 +48,7 @@ export default function EndToEndTesting() {
     const idToPanelMap = idToPanelMapRef.current;
     const panel = idToPanelMap.get(panelId);
     if (panel) {
-      panel.expand();
+      panel.expand(checked ? 'before': 'after');
     }
   };
 
@@ -82,6 +84,15 @@ export default function EndToEndTesting() {
           onChange={onSizeInputChange}
           type="number"
         />
+        <label>
+          reverse
+          <input
+            id="direction"
+            checked={checked}
+            onChange={event => setChecked(event.target.checked)}
+            type="checkbox"
+          />
+        </label>
       </div>
       <div className={styles.Children}>{children}</div>
       <DebugLog apiRef={debugLogRef} />

--- a/packages/react-resizable-panels-website/src/routes/examples/ImperativeApi.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/ImperativeApi.tsx
@@ -90,6 +90,8 @@ function TogglesRow({
 }) {
   const [size, setSize] = useState(20);
 
+  const [isCollapseReverse, setCollapseReverse] = useState(false);
+
   const onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const input = event.currentTarget as HTMLInputElement;
     setSize(parseInt(input.value));
@@ -108,7 +110,7 @@ function TogglesRow({
           panelSize === 0 ? sharedStyles.ButtonDisabled : sharedStyles.Button
         }
         data-test-id={`collapse-button-${id}`}
-        onClick={() => panelRef.current.collapse()}
+        onClick={() => panelRef.current.collapse(isCollapseReverse && 'before')}
         title={`Collapse ${id} panel`}
       >
         <Icon type="horizontal-collapse" />
@@ -118,7 +120,7 @@ function TogglesRow({
           panelSize !== 0 ? sharedStyles.ButtonDisabled : sharedStyles.Button
         }
         data-test-id={`expand-button-${id}`}
-        onClick={() => panelRef.current.expand()}
+        onClick={() => panelRef.current.expand(isCollapseReverse && 'before')}
         title={`Expand ${id} panel`}
       >
         <Icon type="horizontal-expand" />
@@ -135,6 +137,16 @@ function TogglesRow({
           value={size}
         />
       </form>
+      <label>
+        collapse to reverse direction
+        <input type='checkbox' checked={isCollapseReverse}
+          onChange={
+            event => {
+              setCollapseReverse(event.target.checked)
+            }
+          }
+        />
+      </label>
     </div>
   );
 }
@@ -182,7 +194,7 @@ function Content({
             collapsible
             defaultSize={sizes.left}
             id="left"
-            maxSize={30}
+            // maxSize={50}
             minSize={10}
             onResize={(left: number) => onResize({ left })}
             order={1}

--- a/packages/react-resizable-panels-website/src/routes/examples/ImperativeApi.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/ImperativeApi.tsx
@@ -110,7 +110,9 @@ function TogglesRow({
           panelSize === 0 ? sharedStyles.ButtonDisabled : sharedStyles.Button
         }
         data-test-id={`collapse-button-${id}`}
-        onClick={() => panelRef.current.collapse(isCollapseReverse ? 'before' : null)}
+        onClick={() =>
+          panelRef.current.collapse(isCollapseReverse ? "before" : null)
+        }
         title={`Collapse ${id} panel`}
       >
         <Icon type="horizontal-collapse" />
@@ -120,7 +122,9 @@ function TogglesRow({
           panelSize !== 0 ? sharedStyles.ButtonDisabled : sharedStyles.Button
         }
         data-test-id={`expand-button-${id}`}
-        onClick={() => panelRef.current.expand(isCollapseReverse ? 'before' : null)}
+        onClick={() =>
+          panelRef.current.expand(isCollapseReverse ? "before" : null)
+        }
         title={`Expand ${id} panel`}
       >
         <Icon type="horizontal-expand" />
@@ -139,12 +143,12 @@ function TogglesRow({
       </form>
       <label>
         collapse to reverse direction
-        <input type='checkbox' checked={isCollapseReverse}
-          onChange={
-            event => {
-              setCollapseReverse(event.target.checked)
-            }
-          }
+        <input
+          type="checkbox"
+          checked={isCollapseReverse}
+          onChange={(event) => {
+            setCollapseReverse(event.target.checked);
+          }}
         />
       </label>
     </div>

--- a/packages/react-resizable-panels-website/src/routes/examples/ImperativeApi.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/ImperativeApi.tsx
@@ -110,7 +110,7 @@ function TogglesRow({
           panelSize === 0 ? sharedStyles.ButtonDisabled : sharedStyles.Button
         }
         data-test-id={`collapse-button-${id}`}
-        onClick={() => panelRef.current.collapse(isCollapseReverse && 'before')}
+        onClick={() => panelRef.current.collapse(isCollapseReverse ? 'before' : null)}
         title={`Collapse ${id} panel`}
       >
         <Icon type="horizontal-collapse" />
@@ -120,7 +120,7 @@ function TogglesRow({
           panelSize !== 0 ? sharedStyles.ButtonDisabled : sharedStyles.Button
         }
         data-test-id={`expand-button-${id}`}
-        onClick={() => panelRef.current.expand(isCollapseReverse && 'before')}
+        onClick={() => panelRef.current.expand(isCollapseReverse ? 'before' : null)}
         title={`Expand ${id} panel`}
       >
         <Icon type="horizontal-expand" />

--- a/packages/react-resizable-panels-website/tests/ImperativeApi.spec.ts
+++ b/packages/react-resizable-panels-website/tests/ImperativeApi.spec.ts
@@ -105,7 +105,7 @@ test.describe("Imperative Panel API", () => {
     await verifySizes(page, 30, 60, 10);
   });
 
-  test("should expand imperatively collapsed panels to size before collapse", async ({
+  test("should expand imperatively collapsed panels to size before collapse @test2", async ({
     page,
   }) => {
     const collapseButton = page.locator("#collapseButton");
@@ -113,6 +113,7 @@ test.describe("Imperative Panel API", () => {
     const panelIdInput = page.locator("#panelIdInput");
     const resizeButton = page.locator("#resizeButton");
     const sizeInput = page.locator("#sizeInput");
+    const directionCheckbox = page.locator("#direction");
 
     await panelIdInput.focus();
     await panelIdInput.fill("left");
@@ -141,6 +142,25 @@ test.describe("Imperative Panel API", () => {
     await verifySizes(page, 15, 85, 0);
     await expandButton.click();
     await verifySizes(page, 15, 60, 25);
+
+    // Middle pane collapse/expand with direction
+
+    // reset size to 20 10 70
+    await panelIdInput.focus();
+    await panelIdInput.fill("right");
+    await sizeInput.fill("70");
+    await resizeButton.click();
+    await panelIdInput.fill("left");
+    await sizeInput.fill("20");
+    await resizeButton.click();
+    await panelIdInput.fill("middle");
+
+    // reverse case
+    await directionCheckbox.click()
+    await collapseButton.click()
+    await verifySizes(page, 30, 0, 70);
+    await expandButton.click()
+    await verifySizes(page, 20, 10, 70);
   });
 
   test("should expand drag collapsed panels to their most recent size", async ({

--- a/packages/react-resizable-panels-website/tests/ImperativeApi.spec.ts
+++ b/packages/react-resizable-panels-website/tests/ImperativeApi.spec.ts
@@ -105,7 +105,7 @@ test.describe("Imperative Panel API", () => {
     await verifySizes(page, 30, 60, 10);
   });
 
-  test("should expand imperatively collapsed panels to size before collapse @test2", async ({
+  test("should expand imperatively collapsed panels to size before collapse", async ({
     page,
   }) => {
     const collapseButton = page.locator("#collapseButton");
@@ -156,10 +156,10 @@ test.describe("Imperative Panel API", () => {
     await panelIdInput.fill("middle");
 
     // reverse case
-    await directionCheckbox.click()
-    await collapseButton.click()
+    await directionCheckbox.click();
+    await collapseButton.click();
     await verifySizes(page, 30, 0, 70);
-    await expandButton.click()
+    await expandButton.click();
     await verifySizes(page, 20, 10, 70);
   });
 

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -14,7 +14,7 @@ import useIsomorphicLayoutEffect from "./hooks/useIsomorphicEffect";
 import useUniqueId from "./hooks/useUniqueId";
 
 import { PanelGroupContext } from "./PanelContexts";
-import { PanelOnCollapse, PanelOnResize, AffectDirection } from './types';
+import { PanelOnCollapse, PanelOnResize, AffectDirection } from "./types";
 
 export type PanelProps = {
   children?: ReactNode;
@@ -146,8 +146,10 @@ function PanelWithForwardedRef({
   useImperativeHandle(
     forwardedRef,
     () => ({
-      collapse: (affectDirection = 'after') => collapsePanel(panelId, affectDirection as AffectDirection),
-      expand: (affectDirection = 'after') => expandPanel(panelId, affectDirection as AffectDirection),
+      collapse: (affectDirection = "after") =>
+        collapsePanel(panelId, affectDirection as AffectDirection),
+      expand: (affectDirection = "after") =>
+        expandPanel(panelId, affectDirection as AffectDirection),
       getCollapsed() {
         return committedValuesRef.current.size === 0;
       },

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -14,7 +14,7 @@ import useIsomorphicLayoutEffect from "./hooks/useIsomorphicEffect";
 import useUniqueId from "./hooks/useUniqueId";
 
 import { PanelGroupContext } from "./PanelContexts";
-import { PanelOnCollapse, PanelOnResize } from "./types";
+import { PanelOnCollapse, PanelOnResize, AffectDirection } from './types';
 
 export type PanelProps = {
   children?: ReactNode;
@@ -32,8 +32,8 @@ export type PanelProps = {
 };
 
 export type ImperativePanelHandle = {
-  collapse: () => void;
-  expand: () => void;
+  collapse: (direction?: AffectDirection) => void;
+  expand: (direction?: AffectDirection) => void;
   getCollapsed(): boolean;
   getSize(): number;
   resize: (percentage: number) => void;
@@ -146,8 +146,8 @@ function PanelWithForwardedRef({
   useImperativeHandle(
     forwardedRef,
     () => ({
-      collapse: (affectDirection = 'after') => collapsePanel(panelId, affectDirection),
-      expand: (affectDirection = 'after') => expandPanel(panelId, affectDirection),
+      collapse: (affectDirection = 'after') => collapsePanel(panelId, affectDirection as AffectDirection),
+      expand: (affectDirection = 'after') => expandPanel(panelId, affectDirection as AffectDirection),
       getCollapsed() {
         return committedValuesRef.current.size === 0;
       },

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -146,8 +146,8 @@ function PanelWithForwardedRef({
   useImperativeHandle(
     forwardedRef,
     () => ({
-      collapse: () => collapsePanel(panelId),
-      expand: () => expandPanel(panelId),
+      collapse: (affectDirection = 'after') => collapsePanel(panelId, affectDirection),
+      expand: (affectDirection = 'after') => expandPanel(panelId, affectDirection),
       getCollapsed() {
         return committedValuesRef.current.size === 0;
       },

--- a/packages/react-resizable-panels/src/PanelContexts.ts
+++ b/packages/react-resizable-panels/src/PanelContexts.ts
@@ -1,6 +1,11 @@
 import { CSSProperties, createContext } from "react";
 
-import { PanelData, ResizeEvent, ResizeHandler, AffectDirection } from './types';
+import {
+  PanelData,
+  ResizeEvent,
+  ResizeHandler,
+  AffectDirection,
+} from "./types";
 
 export const PanelGroupContext = createContext<{
   activeHandleId: string | null;

--- a/packages/react-resizable-panels/src/PanelContexts.ts
+++ b/packages/react-resizable-panels/src/PanelContexts.ts
@@ -1,12 +1,12 @@
 import { CSSProperties, createContext } from "react";
 
-import { PanelData, ResizeEvent, ResizeHandler } from "./types";
+import { PanelData, ResizeEvent, ResizeHandler, AffectDirection } from './types';
 
 export const PanelGroupContext = createContext<{
   activeHandleId: string | null;
-  collapsePanel: (id: string) => void;
+  collapsePanel: (id: string, direction: AffectDirection) => void;
   direction: "horizontal" | "vertical";
-  expandPanel: (id: string) => void;
+  expandPanel: (id: string, direction: AffectDirection) => void;
   getPanelStyle: (id: string) => CSSProperties;
   groupId: string;
   registerPanel: (id: string, panel: PanelData) => void;

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -426,10 +426,10 @@ export function PanelGroup({
     });
   }, []);
 
-  const collapsePanel = useCallback((id: string, affectDirection = 'after') => {
+  const collapsePanel = useCallback((id: string, affectDirection = "after") => {
     const { panels, sizes: prevSizes } = committedValuesRef.current;
 
-    if (!affectDirection) affectDirection = 'after'
+    if (!affectDirection) affectDirection = "after";
 
     const panel = panels.get(id);
     if (panel == null || !panel.collapsible) {
@@ -451,7 +451,11 @@ export function PanelGroup({
 
     panelSizeBeforeCollapse.current.set(id, currentSize);
 
-    const [idBefore, idAfter] = getBeforeAndAfterIds(id, panelsArray, affectDirection === 'before');
+    const [idBefore, idAfter] = getBeforeAndAfterIds(
+      id,
+      panelsArray,
+      affectDirection === "before"
+    );
     if (idBefore == null || idAfter == null) {
       return;
     }
@@ -459,12 +463,12 @@ export function PanelGroup({
     const isLastPanel = index === panelsArray.length - 1;
     const isFirstPanel = index === 0;
     // let delta = isLastPanel ? currentSize : 0 - currentSize;
-    let delta 
+    let delta;
 
-    if (affectDirection === 'before' || isLastPanel) {
-      delta = currentSize
-    } else if (affectDirection === 'after' || isFirstPanel) {
-      delta = -currentSize
+    if (affectDirection === "before" || isLastPanel) {
+      delta = currentSize;
+    } else if (affectDirection === "after" || isFirstPanel) {
+      delta = -currentSize;
     }
 
     const nextSizes = adjustByDelta(
@@ -485,9 +489,9 @@ export function PanelGroup({
     }
   }, []);
 
-  const expandPanel = useCallback((id: string, affectDirection = 'after') => {
+  const expandPanel = useCallback((id: string, affectDirection = "after") => {
     const { panels, sizes: prevSizes } = committedValuesRef.current;
-    if (!affectDirection) affectDirection = 'after'
+    if (!affectDirection) affectDirection = "after";
 
     const panel = panels.get(id);
     if (panel == null) {
@@ -512,8 +516,10 @@ export function PanelGroup({
       return;
     }
 
-    const [idBefore, idAfter] = getBeforeAndAfterIds(id, panelsArray,
-      affectDirection === 'before'
+    const [idBefore, idAfter] = getBeforeAndAfterIds(
+      id,
+      panelsArray,
+      affectDirection === "before"
     );
     if (idBefore == null || idAfter == null) {
       return;
@@ -524,9 +530,9 @@ export function PanelGroup({
 
     let delta;
 
-    if (affectDirection === 'before' || isLastPanel) {
+    if (affectDirection === "before" || isLastPanel) {
       delta = -sizeBeforeCollapse;
-    } else if (affectDirection === 'after' || isFirstPanel) {
+    } else if (affectDirection === "after" || isFirstPanel) {
       delta = sizeBeforeCollapse;
     }
     // delta = isLastPanel ? 0 - sizeBeforeCollapse : sizeBeforeCollapse;

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -426,8 +426,10 @@ export function PanelGroup({
     });
   }, []);
 
-  const collapsePanel = useCallback((id: string) => {
+  const collapsePanel = useCallback((id: string, affectDirection = 'after') => {
     const { panels, sizes: prevSizes } = committedValuesRef.current;
+
+    if (!affectDirection) affectDirection = 'after'
 
     const panel = panels.get(id);
     if (panel == null || !panel.collapsible) {
@@ -449,13 +451,21 @@ export function PanelGroup({
 
     panelSizeBeforeCollapse.current.set(id, currentSize);
 
-    const [idBefore, idAfter] = getBeforeAndAfterIds(id, panelsArray);
+    const [idBefore, idAfter] = getBeforeAndAfterIds(id, panelsArray, affectDirection === 'before');
     if (idBefore == null || idAfter == null) {
       return;
     }
 
     const isLastPanel = index === panelsArray.length - 1;
-    const delta = isLastPanel ? currentSize : 0 - currentSize;
+    const isFirstPanel = index === 0;
+    // let delta = isLastPanel ? currentSize : 0 - currentSize;
+    let delta 
+
+    if (affectDirection === 'before' || isLastPanel) {
+      delta = currentSize
+    } else if (affectDirection === 'after' || isFirstPanel) {
+      delta = -currentSize
+    }
 
     const nextSizes = adjustByDelta(
       null,
@@ -475,8 +485,9 @@ export function PanelGroup({
     }
   }, []);
 
-  const expandPanel = useCallback((id: string) => {
+  const expandPanel = useCallback((id: string, affectDirection = 'after') => {
     const { panels, sizes: prevSizes } = committedValuesRef.current;
+    if (!affectDirection) affectDirection = 'after'
 
     const panel = panels.get(id);
     if (panel == null) {
@@ -495,20 +506,30 @@ export function PanelGroup({
     if (index < 0) {
       return;
     }
-
     const currentSize = prevSizes[index];
     if (currentSize !== 0) {
       // Panel is already expanded.
       return;
     }
 
-    const [idBefore, idAfter] = getBeforeAndAfterIds(id, panelsArray);
+    const [idBefore, idAfter] = getBeforeAndAfterIds(id, panelsArray,
+      affectDirection === 'before'
+    );
     if (idBefore == null || idAfter == null) {
       return;
     }
 
     const isLastPanel = index === panelsArray.length - 1;
-    const delta = isLastPanel ? 0 - sizeBeforeCollapse : sizeBeforeCollapse;
+    const isFirstPanel = index === 0;
+
+    let delta;
+
+    if (affectDirection === 'before' || isLastPanel) {
+      delta = -sizeBeforeCollapse;
+    } else if (affectDirection === 'after' || isFirstPanel) {
+      delta = sizeBeforeCollapse;
+    }
+    // delta = isLastPanel ? 0 - sizeBeforeCollapse : sizeBeforeCollapse;
 
     const nextSizes = adjustByDelta(
       null,

--- a/packages/react-resizable-panels/src/types.ts
+++ b/packages/react-resizable-panels/src/types.ts
@@ -2,6 +2,8 @@ import { RefObject } from "react";
 
 export type Direction = "horizontal" | "vertical";
 
+export type AffectDirection = 'before' | 'after'
+
 export type PanelGroupStorage = {
   getItem(name: string): string | null;
   setItem(name: string, value: string): void;

--- a/packages/react-resizable-panels/src/types.ts
+++ b/packages/react-resizable-panels/src/types.ts
@@ -2,7 +2,7 @@ import { RefObject } from "react";
 
 export type Direction = "horizontal" | "vertical";
 
-export type AffectDirection = 'before' | 'after'
+export type AffectDirection = "before" | "after";
 
 export type PanelGroupStorage = {
   getItem(name: string): string | null;

--- a/packages/react-resizable-panels/src/utils/group.ts
+++ b/packages/react-resizable-panels/src/utils/group.ts
@@ -145,7 +145,8 @@ export function callPanelCallbacks(
 
 export function getBeforeAndAfterIds(
   id: string,
-  panelsArray: PanelData[]
+  panelsArray: PanelData[],
+  shouldOffsetForward = false,
 ): [idBefore: string | null, idAFter: string | null] {
   if (panelsArray.length < 2) {
     return [null, null];
@@ -156,11 +157,17 @@ export function getBeforeAndAfterIds(
     return [null, null];
   }
 
+  const isFirstPanel = index === 0;
   const isLastPanel = index === panelsArray.length - 1;
-  const idBefore = isLastPanel ? panelsArray[index - 1].id : id;
-  const idAfter = isLastPanel ? id : panelsArray[index + 1].id;
-
-  return [idBefore, idAfter];
+  if (!isFirstPanel && shouldOffsetForward) {
+    const idBefore = panelsArray[index - 1].id;
+    const idAfter = id;
+    return [idBefore, idAfter];
+  } else {
+    const idBefore = isLastPanel ? panelsArray[index - 1].id : id;
+    const idAfter = isLastPanel ? id : panelsArray[index + 1].id; 
+    return [idBefore, idAfter];
+  }
 }
 
 // This method returns a number between 1 and 100 representing

--- a/packages/react-resizable-panels/src/utils/group.ts
+++ b/packages/react-resizable-panels/src/utils/group.ts
@@ -146,7 +146,7 @@ export function callPanelCallbacks(
 export function getBeforeAndAfterIds(
   id: string,
   panelsArray: PanelData[],
-  shouldOffsetForward = false,
+  shouldOffsetForward = false
 ): [idBefore: string | null, idAFter: string | null] {
   if (panelsArray.length < 2) {
     return [null, null];
@@ -165,7 +165,7 @@ export function getBeforeAndAfterIds(
     return [idBefore, idAfter];
   } else {
     const idBefore = isLastPanel ? panelsArray[index - 1].id : id;
-    const idAfter = isLastPanel ? id : panelsArray[index + 1].id; 
+    const idAfter = isLastPanel ? id : panelsArray[index + 1].id;
     return [idBefore, idAfter];
   }
 }


### PR DESCRIPTION
Add affect direction to Panel imperative api collapse/expand
```
type AffectDirection = 'before' | 'after';
collapse: (direction?: AffectDirection) => void;
expand: (direction?: AffectDirection) => void;
```
It means a Panel when be collapsed by imperative api, it will affect the sibling panel's size before or after it, default is after.