### PR TITLE
Add getElement() functions to Panel and PanelGroup

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -37,6 +37,7 @@ export type PanelProps = {
 };
 
 export type ImperativePanelHandle = {
+  getElement: () => HTMLElement | null;
   collapse: () => void;
   expand: () => void;
   getCollapsed(): boolean;
@@ -154,9 +155,12 @@ function PanelWithForwardedRef({
     };
   }, [registerPanel, unregisterPanel]);
 
+  const elementRef = useRef<HTMLElement>(null);
+
   useImperativeHandle(
     forwardedRef,
     () => ({
+      getElement: () => elementRef.current,
       collapse: () => collapsePanel(panelId),
       expand: () => expandPanel(panelId),
       getCollapsed() {
@@ -182,6 +186,7 @@ function PanelWithForwardedRef({
       ...style,
       ...styleFromProps,
     },
+    ref: elementRef,
   });
 }
 

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -109,6 +109,7 @@ export type PanelGroupProps = {
 };
 
 export type ImperativePanelGroupHandle = {
+  getElement: () => HTMLElement | null;
   getLayout: () => number[];
   setLayout: (panelSizes: number[]) => void;
 };
@@ -161,9 +162,12 @@ function PanelGroupWithForwardedRef({
     sizes,
   });
 
+  const elementRef = useRef<HTMLElement>(null);
+
   useImperativeHandle(
     forwardedRef,
     () => ({
+      getElement: () => elementRef.current,
       getLayout: () => {
         const { sizes } = committedValuesRef.current;
         return sizes;
@@ -688,6 +692,7 @@ function PanelGroupWithForwardedRef({
       "data-panel-group-direction": direction,
       "data-panel-group-id": groupId,
       style: { ...style, ...styleFromProps },
+      ref: elementRef,
     }),
     value: context,
   });


### PR DESCRIPTION
This makes it much easier to do stuff like in https://github.com/bvaughn/react-resizable-panels/issues/48#issuecomment-1368106118, because you don't need a querySelector anymore but can use the ref to target the group or panel directly.

Also, this is the minimal implementation needed to get this working (I think), feel free to adjust & fix anything I missed.