### PR TITLE
feat: support Panel disabled

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -34,6 +34,7 @@ export type PanelProps = {
   order?: number | null;
   style?: CSSProperties;
   tagName?: ElementType;
+  disabled?: boolean;
 };
 
 export type ImperativePanelHandle = {
@@ -58,6 +59,7 @@ function PanelWithForwardedRef({
   order = null,
   style: styleFromProps = {},
   tagName: Type = "div",
+  disabled = false,
 }: PanelProps & {
   forwardedRef: ForwardedRef<ImperativePanelHandle>;
 }) {
@@ -110,7 +112,7 @@ function PanelWithForwardedRef({
     }
   }
 
-  const style = getPanelStyle(panelId, defaultSize);
+  const style = disabled ? {} : getPanelStyle(panelId, defaultSize);
 
   const committedValuesRef = useRef<{
     size: number;
@@ -147,12 +149,13 @@ function PanelWithForwardedRef({
   });
 
   useIsomorphicLayoutEffect(() => {
-    registerPanel(panelId, panelDataRef as PanelData);
-
-    return () => {
-      unregisterPanel(panelId);
-    };
-  }, [order, panelId, registerPanel, unregisterPanel]);
+    if (!disabled) {
+      registerPanel(panelId, panelDataRef as PanelData);
+      return () => {
+        unregisterPanel(panelId);
+      };
+    }
+  }, [disabled, order, panelId, registerPanel, unregisterPanel]);
 
   useImperativeHandle(
     forwardedRef,
@@ -176,7 +179,9 @@ function PanelWithForwardedRef({
     "data-panel": "",
     "data-panel-collapsible": collapsible || undefined,
     "data-panel-id": panelId,
-    "data-panel-size": parseFloat("" + style.flexGrow).toFixed(1),
+    "data-panel-size": disabled
+      ? undefined
+      : parseFloat("" + style.flexGrow).toFixed(1),
     id: `data-panel-id-${panelId}`,
     style: {
       ...style,


### PR DESCRIPTION
When I use Conditional panels, For example:
```
<>
  <Panel>top</Panel>
  {enabled && <PanelResizeHandle />}
  {enabled ? <Panel defaultSize={40}>{content}</Panel> : <div>{content}</div>}
</>
```

When enabled changes, content will be destroyed.  The content takes a long time to render and loses state, so I don't want it to be destroyed.
In order to solve this problem, I want the Panel to provide a disabled attribute. When disabled is true, disable the resizable function of the Panel.the code becomes:
```
<>
  <Panel>top</Panel>
  {enabled && <PanelResizeHandle />}
  <Panel defaultSize={40} disabled={!enabled}>{content}</Panel>
</>
```

Or expose the PanelGroupContext so that I can customize the Panel ?