### PR TITLE
lazily initialize the default storage

### DIFF
--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -60,16 +60,24 @@ function throwServerError() {
   throw new Error('PanelGroup "storage" prop required for server rendering.');
 }
 
-const defaultStorage: PanelGroupStorage = {
-  getItem:
-    typeof localStorage !== "undefined"
-      ? (name: string) => localStorage.getItem(name)
-      : (throwServerError as any),
-  setItem:
-    typeof localStorage !== "undefined"
-      ? (name: string, value: string) => localStorage.setItem(name, value)
-      : (throwServerError as any),
-};
+let defaultStorage: null | PanelGroupStorage = null
+
+function initializeDefaultStorage(): PanelGroupStorage {
+  if (defaultStorage === null) {
+    defaultStorage = {
+      getItem:
+        typeof localStorage !== "undefined"
+          ? (name: string) => localStorage.getItem(name)
+          : (throwServerError as any),
+      setItem:
+        typeof localStorage !== "undefined"
+          ? (name: string, value: string) => localStorage.setItem(name, value)
+          : (throwServerError as any),
+    };
+  }
+
+  return defaultStorage
+}
 
 export type CommittedValues = {
   direction: Direction;
@@ -123,7 +131,7 @@ function PanelGroupWithForwardedRef({
   forwardedRef,
   id: idFromProps = null,
   onLayout,
-  storage = defaultStorage,
+  storage = initializeDefaultStorage(),
   style: styleFromProps = {},
   tagName: Type = "div",
 }: PanelGroupProps & {


### PR DESCRIPTION
In order to avoid issues in an environment where third-party cookies are disabled, the default storage needs to be lazily initialised.

I don't have a minimal reproduction yet, I could get to that if you want me to.