### PR TITLE
Panel onResize not called if there is no onLayout

### DIFF
--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -236,7 +236,9 @@ function PanelGroupWithForwardedRef({
 
     // Don't commit layout until all panels have registered and re-rendered with their actual sizes.
     if (sizes.length > 0) {
-      onLayout?.(sizes);
+      if (onLayout) {
+        onLayout(sizes);
+      }
 
       const panelIdToLastNotifiedSizeMap =
         panelIdToLastNotifiedSizeMapRef.current;

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -232,24 +232,22 @@ function PanelGroupWithForwardedRef({
   // Notify external code when sizes have changed.
   useEffect(() => {
     const { onLayout } = callbacksRef.current!;
-    if (onLayout) {
-      const { panels, sizes } = committedValuesRef.current;
+    const { panels, sizes } = committedValuesRef.current;
 
-      // Don't commit layout until all panels have registered and re-rendered with their actual sizes.
-      if (sizes.length > 0) {
-        onLayout(sizes);
+    // Don't commit layout until all panels have registered and re-rendered with their actual sizes.
+    if (sizes.length > 0) {
+      onLayout?.(sizes);
 
-        const panelIdToLastNotifiedSizeMap =
-          panelIdToLastNotifiedSizeMapRef.current;
+      const panelIdToLastNotifiedSizeMap =
+        panelIdToLastNotifiedSizeMapRef.current;
 
-        // When possible, we notify before the next render so that rendering work can be batched together.
-        // Some cases are difficult to detect though,
-        // for example– panels that are conditionally rendered can affect the size of neighboring panels.
-        // In this case, the best we can do is notify on commit.
-        // The callPanelCallbacks() uses its own memoization to avoid notifying panels twice in these cases.
-        const panelsArray = panelsMapToSortedArray(panels);
-        callPanelCallbacks(panelsArray, sizes, panelIdToLastNotifiedSizeMap);
-      }
+      // When possible, we notify before the next render so that rendering work can be batched together.
+      // Some cases are difficult to detect though,
+      // for example– panels that are conditionally rendered can affect the size of neighboring panels.
+      // In this case, the best we can do is notify on commit.
+      // The callPanelCallbacks() uses its own memoization to avoid notifying panels twice in these cases.
+      const panelsArray = panelsMapToSortedArray(panels);
+      callPanelCallbacks(panelsArray, sizes, panelIdToLastNotifiedSizeMap);
     }
   }, [sizes]);
 


### PR DESCRIPTION
For the initial render, if the layout is restored from local storage, the Panel's `onResize` function is only called if the PanelGroup has a `onLayout`. This is not expected and I assume was not intentional?

In this PR I just removed the `if (onLayout)` check in favor of a `onLayout?.(sizes)` later on.