### PR TITLE
Add option to have transition

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -35,6 +35,7 @@ export type PanelProps = {
   order?: number | null;
   style?: CSSProperties;
   tagName?: ElementType;
+  transition?: string;
 };
 
 export type ImperativePanelHandle = {
@@ -60,6 +61,7 @@ function PanelWithForwardedRef({
   order = null,
   style: styleFromProps = {},
   tagName: Type = "div",
+  transition = "0s",
 }: PanelProps & {
   forwardedRef: ForwardedRef<ImperativePanelHandle>;
 }) {
@@ -112,7 +114,7 @@ function PanelWithForwardedRef({
     }
   }
 
-  const style = getPanelStyle(panelId, defaultSize);
+  const style = getPanelStyle(panelId, defaultSize, transition);
 
   const committedValuesRef = useRef<{
     size: number;

--- a/packages/react-resizable-panels/src/PanelContexts.ts
+++ b/packages/react-resizable-panels/src/PanelContexts.ts
@@ -7,7 +7,11 @@ export const PanelGroupContext = createContext<{
   collapsePanel: (id: string) => void;
   direction: "horizontal" | "vertical";
   expandPanel: (id: string) => void;
-  getPanelStyle: (id: string, defaultSize: number | null) => CSSProperties;
+  getPanelStyle: (
+    id: string,
+    defaultSize: number | null,
+    transition: string
+  ) => CSSProperties;
   groupId: string;
   registerPanel: (id: string, panel: PanelData) => void;
   registerResizeHandle: (id: string) => ResizeHandler;

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -337,7 +337,11 @@ function PanelGroupWithForwardedRef({
   }, [autoSaveId, panels, sizes, storage]);
 
   const getPanelStyle = useCallback(
-    (id: string, defaultSize: number | null): CSSProperties => {
+    (
+      id: string,
+      defaultSize: number | null,
+      transition: string
+    ): CSSProperties => {
       const { panels } = committedValuesRef.current;
 
       // Before mounting, Panels will not yet have registered themselves.
@@ -359,6 +363,7 @@ function PanelGroupWithForwardedRef({
 
           // Without this, Panel sizes may be unintentionally overridden by their content.
           overflow: "hidden",
+          transition: `flex-grow ${transition} ease-in-out`,
         };
       }
 
@@ -371,6 +376,7 @@ function PanelGroupWithForwardedRef({
 
         // Without this, Panel sizes may be unintentionally overridden by their content.
         overflow: "hidden",
+        transition: `flex-grow ${transition} ease-in-out`,
 
         // Disable pointer events inside of a panel during resize.
         // This avoid edge cases like nested iframes.


### PR DESCRIPTION
This PR adds an optional prop to the `Panel` component to make it possible for it to have a transition on collapse/expand. Needed for replayio/devtools#8914