### PR TITLE
Add worker condition

### DIFF
--- a/packages/react-resizable-panels/package.json
+++ b/packages/react-resizable-panels/package.json
@@ -17,11 +17,31 @@
         "import": "./dist/react-resizable-panels.cjs.mjs",
         "default": "./dist/react-resizable-panels.cjs.js"
       },
-      "development": {
-        "browser": {
+      "browser": {
+        "development": {
+          "worker": {
+            "module": "./dist/react-resizable-panels.development.worker.esm.js",
+            "import": "./dist/react-resizable-panels.development.worker.cjs.mjs",
+            "default": "./dist/react-resizable-panels.development.worker.cjs.js"
+          },
           "module": "./dist/react-resizable-panels.browser.development.esm.js",
           "import": "./dist/react-resizable-panels.browser.development.cjs.mjs",
           "default": "./dist/react-resizable-panels.browser.development.cjs.js"
+        },
+        "worker": {
+          "module": "./dist/react-resizable-panels.worker.esm.js",
+          "import": "./dist/react-resizable-panels.worker.cjs.mjs",
+          "default": "./dist/react-resizable-panels.worker.cjs.js"
+        },
+        "module": "./dist/react-resizable-panels.browser.esm.js",
+        "import": "./dist/react-resizable-panels.browser.cjs.mjs",
+        "default": "./dist/react-resizable-panels.browser.cjs.js"
+      },
+      "development": {
+        "worker": {
+          "module": "./dist/react-resizable-panels.development.worker.esm.js",
+          "import": "./dist/react-resizable-panels.development.worker.cjs.mjs",
+          "default": "./dist/react-resizable-panels.development.worker.cjs.js"
         },
         "node": {
           "module": "./dist/react-resizable-panels.development.node.esm.js",
@@ -32,10 +52,10 @@
         "import": "./dist/react-resizable-panels.development.cjs.mjs",
         "default": "./dist/react-resizable-panels.development.cjs.js"
       },
-      "browser": {
-        "module": "./dist/react-resizable-panels.browser.esm.js",
-        "import": "./dist/react-resizable-panels.browser.cjs.mjs",
-        "default": "./dist/react-resizable-panels.browser.cjs.js"
+      "worker": {
+        "module": "./dist/react-resizable-panels.worker.esm.js",
+        "import": "./dist/react-resizable-panels.worker.cjs.mjs",
+        "default": "./dist/react-resizable-panels.worker.cjs.js"
       },
       "node": {
         "module": "./dist/react-resizable-panels.node.esm.js",
@@ -54,6 +74,7 @@
       "default": "./src/env-conditions/production.ts"
     },
     "#is-browser": {
+      "worker": "./src/env-conditions/worker.ts",
       "browser": "./src/env-conditions/browser.ts",
       "node": "./src/env-conditions/node.ts",
       "default": "./src/env-conditions/unknown.ts"

--- a/packages/react-resizable-panels/src/env-conditions/worker.ts
+++ b/packages/react-resizable-panels/src/env-conditions/worker.ts
@@ -1,0 +1,1 @@
+export const isBrowser = false;


### PR DESCRIPTION
Workers (webworkers, edge workers, etc) are meant to be treated as SSR environments - they don't have access to the DOM after all. Bundlers tend to pick the `browser` condition for them (at the very least Next.js and Cloudflare's Wrangler are doing that but IIRC others are doing that as well) so we need to "override" that with an explicit `worker` condition that should be picked by them first, before picking the `browser` condition.

