### PR TITLE
Remove outdated comment about Parcel workaround

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -195,11 +195,8 @@ export const Panel = forwardRef<ImperativePanelHandle, PanelProps>(
     createElement(PanelWithForwardedRef, { ...props, forwardedRef: ref })
 );
 
-// Workaround for Parcel scope hoisting (which renames objects/functions).
-// Casting to :any is required to avoid corrupting the generated TypeScript types.
-// See github.com/parcel-bundler/parcel/issues/8724
-(PanelWithForwardedRef as any).displayName = "Panel";
-(Panel as any).displayName = "forwardRef(Panel)";
+PanelWithForwardedRef.displayName = "Panel";
+Panel.displayName = "forwardRef(Panel)";
 
 // HACK
 function parseSizeFromStyle(style: CSSProperties): number {

--- a/packages/react-resizable-panels/src/PanelContexts.ts
+++ b/packages/react-resizable-panels/src/PanelContexts.ts
@@ -17,7 +17,4 @@ export const PanelGroupContext = createContext<{
   unregisterPanel: (id: string) => void;
 } | null>(null);
 
-// Workaround for Parcel scope hoisting (which renames objects/functions).
-// Casting to :any is required to avoid corrupting the generated TypeScript types.
-// See github.com/parcel-bundler/parcel/issues/8724
-(PanelGroupContext as any).displayName = "PanelGroupContext";
+PanelGroupContext.displayName = "PanelGroupContext";

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -768,8 +768,5 @@ export const PanelGroup = forwardRef<
   createElement(PanelGroupWithForwardedRef, { ...props, forwardedRef: ref })
 );
 
-// Workaround for Parcel scope hoisting (which renames objects/functions).
-// Casting to :any is required to avoid corrupting the generated TypeScript types.
-// See github.com/parcel-bundler/parcel/issues/8724
-(PanelGroupWithForwardedRef as any).displayName = "PanelGroup";
-(PanelGroup as any).displayName = "forwardRef(PanelGroup)";
+PanelGroupWithForwardedRef.displayName = "PanelGroup";
+PanelGroup.displayName = "forwardRef(PanelGroup)";

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -190,7 +190,4 @@ export function PanelResizeHandle({
   });
 }
 
-// Workaround for Parcel scope hoisting (which renames objects/functions).
-// Casting to :any is required to avoid corrupting the generated TypeScript types.
-// See github.com/parcel-bundler/parcel/issues/8724
-(PanelResizeHandle as any).displayName = "PanelResizeHandle";
+PanelResizeHandle.displayName = "PanelResizeHandle";


### PR DESCRIPTION
Those should no longer be needed. If you want to set those explicitly to aid React DevTools in production then I think the `as any` cast is still a preferred approach but for different reasons. TS isn't able to infer from functions with properties so some HOC-like/FP patterns don't work with `React.FC`-like types (see the thread [here](https://github.com/microsoft/TypeScript/issues/30650#issuecomment-486680485)). It's best to keep those as plain functions if possible at type-level (note that components using `forwardRef` are already breaking that rule because the return type of `forwardRef` is a function with extra properties. You can't do much about that though unless you'd be ready to use some casts with types like [this](https://github.com/adobe/react-spectrum/blob/99ca82e87ba2d7fdd54f5b49326fd242320b4b51/packages/react-aria-components/src/utils.tsx#L19-L21))