### PR TITLE
Skip the lifecycle-related code outside of the browser env

### DIFF
--- a/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
+++ b/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
@@ -1,3 +1,4 @@
+import { isBrowser } from "#is-browser";
 import { RefObject, useEffect } from "../vendor/react";
 import { PRECISION } from "../constants";
 
@@ -34,6 +35,9 @@ export function useWindowSplitterPanelGroupBehavior({
   sizes: number[];
   panelSizeBeforeCollapse: RefObject<Map<string, number>>;
 }): void {
+  if (!isBrowser) {
+    return;
+  }
   useEffect(() => {
     const { direction, panels } = committedValuesRef.current!;
 
@@ -170,6 +174,9 @@ export function useWindowSplitterResizeHandlerBehavior({
   handleId: string;
   resizeHandler: ResizeHandler | null;
 }): void {
+  if (!isBrowser) {
+    return;
+  }
   useEffect(() => {
     if (disabled || resizeHandler == null) {
       return;


### PR DESCRIPTION
⚠️ This is just me tinkering with things. Feel free to close this right away.

My line of thinking here is that UI libraries tend to over ship code in node because it's not that easy to serve different codes in browsers and in node. However, a lot of the code that we ship is browser-only - for the server it's just redundant cruft. On the server we can't execute any effects, state is a one-off, etc etc. What if we just throw away client-specific code in node? With the current tooling setup this is actually fairly easy.

I don't expect those code changes to be 100% correct. I just put this together quickly without analyzing this deeply. I just wanted to learn how much we could roughly save by doing smth like this. The result ain't bad at all! With those changes, we go from 5601 bytes (min+gzipped) to 1691 bytes. That's a 70% reduction **on the server side**.