### PR TITLE
Distribute drags over more than just panels directly beside resizers #1

### DIFF
--- a/packages/react-resizable-panels-website/src/routes/examples/Horizontal.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Horizontal.tsx
@@ -34,6 +34,7 @@ function Content() {
     <div className={styles.PanelGroupWrapper}>
       <PanelGroup className={styles.PanelGroup} direction="horizontal">
         <Panel
+          id="left"
           className={styles.PanelRow}
           defaultSize={10}
           minSize={10}
@@ -42,11 +43,17 @@ function Content() {
           <div className={styles.Centered}>left</div>
         </Panel>
         <ResizeHandle className={styles.ResizeHandle} />
-        <Panel className={styles.PanelRow} minSize={10} maxSize={10}>
+        <Panel
+          id="middle"
+          className={styles.PanelRow}
+          minSize={10}
+          maxSize={10}
+        >
           <div className={styles.Centered}>middle</div>
         </Panel>
         <ResizeHandle className={styles.ResizeHandle} />
         <Panel
+          id="middle2"
           className={styles.PanelRow}
           minSize={10}
           defaultSize={15}

--- a/packages/react-resizable-panels-website/src/routes/examples/Horizontal.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Horizontal.tsx
@@ -33,15 +33,34 @@ function Content() {
   return (
     <div className={styles.PanelGroupWrapper}>
       <PanelGroup className={styles.PanelGroup} direction="horizontal">
-        <Panel className={styles.PanelRow} defaultSize={30} minSize={20}>
+        <Panel
+          className={styles.PanelRow}
+          defaultSize={10}
+          minSize={10}
+          maxSize={20}
+        >
           <div className={styles.Centered}>left</div>
         </Panel>
         <ResizeHandle className={styles.ResizeHandle} />
-        <Panel className={styles.PanelRow} minSize={30}>
+        <Panel className={styles.PanelRow} minSize={10} maxSize={10}>
           <div className={styles.Centered}>middle</div>
         </Panel>
         <ResizeHandle className={styles.ResizeHandle} />
-        <Panel className={styles.PanelRow} defaultSize={30} minSize={20}>
+        <Panel
+          className={styles.PanelRow}
+          minSize={10}
+          defaultSize={15}
+          maxSize={20}
+        >
+          <div className={styles.Centered}>middle2</div>
+        </Panel>
+        <ResizeHandle className={styles.ResizeHandle} />
+        <Panel
+          id="right"
+          className={styles.PanelRow}
+          defaultSize={30}
+          minSize={20}
+        >
           <div className={styles.Centered}>right</div>
         </Panel>
       </PanelGroup>

--- a/packages/react-resizable-panels/src/utils/group.ts
+++ b/packages/react-resizable-panels/src/utils/group.ts
@@ -44,7 +44,7 @@ export function adjustByDelta(
   );
   let index = startIndex;
 
-  while (true) {
+  while (index >= 0 && index < panelsArray.length) {
     let hasRoom = false;
 
     // First try adjusting the pivotId panel and any panels after it
@@ -66,7 +66,6 @@ export function adjustByDelta(
         }
 
         deltaApplied += baseSize - nextSize;
-
         nextSizes[index] = nextSize;
 
         // If the panel isn't at it's min size, we can stop here
@@ -77,15 +76,7 @@ export function adjustByDelta(
         }
       }
 
-      if (deltaPixels < 0) {
-        if (--index < 0) {
-          break;
-        }
-      } else {
-        if (++index >= panelsArray.length) {
-          break;
-        }
-      }
+      index = deltaPixels < 0 ? index - 1 : index + 1;
     }
 
     // If we were unable to resize any of the pivot panels or remaining panels, return the previous state.
@@ -144,15 +135,7 @@ export function adjustByDelta(
       break;
     }
 
-    if (deltaPixels < 0) {
-      if (--index < 0) {
-        break;
-      }
-    } else {
-      if (++index >= panelsArray.length) {
-        break;
-      }
-    }
+    index = deltaPixels < 0 ? index - 1 : index + 1;
   }
 
   // If we were unable to resize any of the panels panels, return the previous state.

--- a/packages/react-resizable-panels/src/utils/group.ts
+++ b/packages/react-resizable-panels/src/utils/group.ts
@@ -122,6 +122,7 @@ export function adjustByDelta(
 
     // Check if there is room to add in the opposite direction
     let oppositeIndex = deltaPixels < 0 ? index + 1 : index - 1;
+    let deltaAppliedToOpposite = 0;
     console.log("###", { oppositeIndex, deltaApplied });
 
     if (oppositeIndex >= 0 && oppositeIndex < panelsArray.length) {
@@ -140,7 +141,7 @@ export function adjustByDelta(
           groupSizePixels,
           oppositePanel,
           oppositeBaseSize,
-          oppositeBaseSize + deltaRemaining,
+          oppositeBaseSize + deltaRemaining - deltaAppliedToOpposite,
           event
         );
 
@@ -152,35 +153,26 @@ export function adjustByDelta(
           max: oppositePanel.current.maxSize,
         });
 
-        if (
-          typeof oppositePanel.current.maxSize !== "number" ||
-          oppositeNextSize < oppositePanel.current.maxSize
-        ) {
-          hasRoom = true;
-          break;
+        if (oppositeBaseSize !== oppositeNextSize) {
+          nextSizes[oppositeIndex] = oppositeNextSize;
+          deltaAppliedToOpposite += oppositeNextSize - oppositeBaseSize;
+          deltaApplied += oppositeNextSize - oppositeBaseSize;
+          console.log("### apply opposite", {
+            oppositeBaseSize,
+            oppositeNextSize,
+            deltaApplied,
+          });
+          if (oppositeNextSize !== oppositePanel.current.maxSize) {
+            hasRoom = true;
+            break;
+          }
         }
 
         oppositeIndex = deltaPixels < 0 ? oppositeIndex + 1 : oppositeIndex - 1;
-        deltaApplied += oppositeNextSize - oppositeBaseSize;
       }
 
-      if (!hasRoom || !oppositePanel) {
+      if (!hasRoom) {
         return prevSizes;
-      }
-
-      console.log("### apply opposite", { oppositeBaseSize, oppositeNextSize });
-
-      if (oppositeBaseSize !== oppositeNextSize) {
-        if (oppositeNextSize === 0 && oppositeBaseSize > 0) {
-          panelSizeBeforeCollapse.set(
-            oppositePanel.current.id,
-            oppositeBaseSize
-          );
-        }
-
-        deltaApplied += oppositeNextSize - oppositeBaseSize;
-
-        nextSizes[oppositeIndex] = oppositeNextSize;
       }
     }
 


### PR DESCRIPTION
Took me a few tries and the code could probably be improved but this fixes #181 

The way it work now is:

- when we apply the new sizes in the direction the delta dictates instead of applying it to just that panel the code now checks if that panel is maxed. If it is we continue on to the next panel. If no panels have room to grow resizing stops
- the same logic is applied to panels in the opposite direction of the delta. we check if the panels in that direction are at their min and move on to the next panel. If there are no more panels that can shrink resizing stops.