### PR TITLE
 fix(Panel): onResize missing prevMixedSizes on first render 

### DIFF
--- a/packages/react-resizable-panels/src/Panel.test.tsx
+++ b/packages/react-resizable-panels/src/Panel.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "./utils/test-utils";
 import { createRef } from "./vendor/react";
 
-describe("PanelGroup", () => {
+describe("Panel", () => {
   let expectedWarnings: string[] = [];
   let root: Root;
   let uninstallMockOffsetWidthAndHeight: () => void;

--- a/packages/react-resizable-panels/src/Panel.test.tsx
+++ b/packages/react-resizable-panels/src/Panel.test.tsx
@@ -5,6 +5,7 @@ import {
   MixedSizes,
   Panel,
   PanelGroup,
+  PanelOnResize,
   PanelResizeHandle,
 } from ".";
 import {
@@ -232,6 +233,28 @@ describe("PanelGroup", () => {
       }).toThrow(
         "Panel components must be rendered within a PanelGroup container"
       );
+    });
+  });
+
+  describe("panel callbacks", () => {
+    describe("onResize", () => {
+      it("should call onResize with defined prevMixedSizes on first render", () => {
+        let initPrevMixedSizes;
+        const onResize: PanelOnResize = jest.fn((_, prevMixedSizes) => {
+          initPrevMixedSizes = prevMixedSizes;
+        });
+
+        act(() => {
+          root.render(
+            <PanelGroup direction="horizontal">
+              <Panel onResize={onResize} />
+            </PanelGroup>
+          );
+        });
+
+        expect(onResize).toHaveBeenCalledTimes(1);
+        expect(initPrevMixedSizes).toBeDefined();
+      });
     });
   });
 

--- a/packages/react-resizable-panels/src/utils/callPanelCallbacks.ts
+++ b/packages/react-resizable-panels/src/utils/callPanelCallbacks.ts
@@ -32,6 +32,7 @@ export function callPanelCallbacks(
     const lastNotifiedMixedSizes = panelIdToLastNotifiedMixedSizesMap[panelId];
     if (
       lastNotifiedMixedSizes == null ||
+      lastNotifiedMixedSizes == undefined ||
       mixedSizes.sizePercentage !== lastNotifiedMixedSizes.sizePercentage ||
       mixedSizes.sizePixels !== lastNotifiedMixedSizes.sizePixels
     ) {
@@ -40,7 +41,8 @@ export function callPanelCallbacks(
       const { onCollapse, onExpand, onResize } = callbacks;
 
       if (onResize) {
-        onResize(mixedSizes, lastNotifiedMixedSizes);
+        // On first render, lastNotifiedMixedSizes will be undefined, fall back to mixedSizes
+        onResize(mixedSizes, lastNotifiedMixedSizes ?? mixedSizes);
       }
 
       if (collapsible && (onCollapse || onExpand)) {


### PR DESCRIPTION
`Panel`'s `onResize` callback had `prevMixedSizes` undefined on first render.

- Fall back to its `mixedSizes` when it is nullish
- Add test for this case

Closes #208 