### PR TITLE
fix: make PanelOnResize arg prevMixedSizes optional

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -19,7 +19,7 @@ export type PanelOnCollapse = () => void;
 export type PanelOnExpand = () => void;
 export type PanelOnResize = (
   mixedSizes: MixedSizes,
-  prevMixedSizes: MixedSizes
+  prevMixedSizes: MixedSizes | undefined
 ) => void;
 
 export type PanelCallbacks = {


### PR DESCRIPTION
It is `undefined` on first render.

Closes #208 
Context #209

FWIW, `noUncheckedIndexedAccess` in tsconfig would. have caught this, but it also catches a whole heck of a lot more.