### PR TITLE
fix: resize should not fail when `dragState` is null

### DIFF
--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -711,17 +711,19 @@ function PanelGroupWithForwardedRef({
 
       const pivotIndices = determinePivotIndices(groupId, dragHandleId);
 
-      let delta = calculateDeltaPercentage(
-        event,
-        groupId,
-        dragHandleId,
-        direction,
-        dragState!,
-        {
-          percentage: keyboardResizeByPercentage,
-          pixels: keyboardResizeByPixels,
-        }
-      );
+      let delta = dragState
+        ? calculateDeltaPercentage(
+            event,
+            groupId,
+            dragHandleId,
+            direction,
+            dragState,
+            {
+              percentage: keyboardResizeByPercentage,
+              pixels: keyboardResizeByPixels,
+            }
+          )
+        : 0;
       if (delta === 0) {
         return;
       }


### PR DESCRIPTION
Resolves #223