### PR TITLE
feat: make element types more accurate

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -54,7 +54,7 @@ export type ImperativePanelHandle = {
   resize: (size: number) => void;
 };
 
-export type PanelProps = Omit<HTMLAttributes<ElementType>, "id" | "onResize"> &
+export type PanelProps = Omit<HTMLAttributes<keyof HTMLElementTagNameMap>, "id" | "onResize"> &
   PropsWithChildren<{
     className?: string;
     collapsedSize?: number | undefined;
@@ -68,7 +68,7 @@ export type PanelProps = Omit<HTMLAttributes<ElementType>, "id" | "onResize"> &
     onResize?: PanelOnResize;
     order?: number;
     style?: object;
-    tagName?: ElementType;
+    tagName?: keyof HTMLElementTagNameMap;
   }>;
 
 export function PanelWithForwardedRef({

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -7,6 +7,7 @@ import {
   ForwardedRef,
   HTMLAttributes,
   PropsWithChildren,
+  ReactNode,
   createElement,
   forwardRef,
   useContext,
@@ -92,7 +93,7 @@ export function PanelWithForwardedRef({
   ...rest
 }: PanelProps & {
   forwardedRef: ForwardedRef<ImperativePanelHandle>;
-}) {
+}): ReactNode {
   const context = useContext(PanelGroupContext);
   if (context === null) {
     throw Error(

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -54,7 +54,10 @@ export type ImperativePanelHandle = {
   resize: (size: number) => void;
 };
 
-export type PanelProps = Omit<HTMLAttributes<keyof HTMLElementTagNameMap>, "id" | "onResize"> &
+export type PanelProps = Omit<
+  HTMLAttributes<keyof HTMLElementTagNameMap>,
+  "id" | "onResize"
+> &
   PropsWithChildren<{
     className?: string;
     collapsedSize?: number | undefined;

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -4,7 +4,6 @@ import { PanelGroupContext } from "./PanelGroupContext";
 import useIsomorphicLayoutEffect from "./hooks/useIsomorphicEffect";
 import useUniqueId from "./hooks/useUniqueId";
 import {
-  ElementType,
   ForwardedRef,
   HTMLAttributes,
   PropsWithChildren,

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -68,7 +68,7 @@ const defaultStorage: PanelGroupStorage = {
   },
 };
 
-export type PanelGroupProps = Omit<HTMLAttributes<ElementType>, "id"> &
+export type PanelGroupProps = Omit<HTMLAttributes<keyof HTMLElementTagNameMap>, "id"> &
   PropsWithChildren<{
     autoSaveId?: string | null;
     className?: string;
@@ -78,7 +78,7 @@ export type PanelGroupProps = Omit<HTMLAttributes<ElementType>, "id"> &
     onLayout?: PanelGroupOnLayout | null;
     storage?: PanelGroupStorage;
     style?: CSSProperties;
-    tagName?: ElementType;
+    tagName?: keyof HTMLElementTagNameMap;
   }>;
 
 const debounceMap: {

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -68,9 +68,10 @@ const defaultStorage: PanelGroupStorage = {
   },
 };
 
-type HTMLElementTagName = keyof HTMLElementTagNameMap;
-
-export type PanelGroupProps = Omit<HTMLAttributes<HTMLElementTagName>, "id"> &
+export type PanelGroupProps = Omit<
+  HTMLAttributes<keyof HTMLElementTagNameMap>,
+  "id"
+> &
   PropsWithChildren<{
     autoSaveId?: string | null;
     className?: string;
@@ -80,7 +81,7 @@ export type PanelGroupProps = Omit<HTMLAttributes<HTMLElementTagName>, "id"> &
     onLayout?: PanelGroupOnLayout | null;
     storage?: PanelGroupStorage;
     style?: CSSProperties;
-    tagName?: HTMLElementTagName;
+    tagName?: keyof HTMLElementTagNameMap;
   }>;
 
 const debounceMap: {

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -31,6 +31,7 @@ import {
   ForwardedRef,
   HTMLAttributes,
   PropsWithChildren,
+  ReactNode,
   createElement,
   forwardRef,
   useCallback,
@@ -67,10 +68,9 @@ const defaultStorage: PanelGroupStorage = {
   },
 };
 
-export type PanelGroupProps = Omit<
-  HTMLAttributes<keyof HTMLElementTagNameMap>,
-  "id"
-> &
+type HTMLElementTagName = keyof HTMLElementTagNameMap;
+
+export type PanelGroupProps = Omit<HTMLAttributes<HTMLElementTagName>, "id"> &
   PropsWithChildren<{
     autoSaveId?: string | null;
     className?: string;
@@ -80,7 +80,7 @@ export type PanelGroupProps = Omit<
     onLayout?: PanelGroupOnLayout | null;
     storage?: PanelGroupStorage;
     style?: CSSProperties;
-    tagName?: keyof HTMLElementTagNameMap;
+    tagName?: HTMLElementTagName;
   }>;
 
 const debounceMap: {
@@ -102,7 +102,7 @@ function PanelGroupWithForwardedRef({
   ...rest
 }: PanelGroupProps & {
   forwardedRef: ForwardedRef<ImperativePanelGroupHandle>;
-}) {
+}): ReactNode {
   const groupId = useUniqueId(idFromProps);
 
   const [dragState, setDragState] = useState<DragState | null>(null);

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -68,7 +68,10 @@ const defaultStorage: PanelGroupStorage = {
   },
 };
 
-export type PanelGroupProps = Omit<HTMLAttributes<keyof HTMLElementTagNameMap>, "id"> &
+export type PanelGroupProps = Omit<
+  HTMLAttributes<keyof HTMLElementTagNameMap>,
+  "id"
+> &
   PropsWithChildren<{
     autoSaveId?: string | null;
     className?: string;

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -28,7 +28,6 @@ import { validatePanelConstraints } from "./utils/validatePanelConstraints";
 import { validatePanelGroupLayout } from "./utils/validatePanelGroupLayout";
 import {
   CSSProperties,
-  ElementType,
   ForwardedRef,
   HTMLAttributes,
   PropsWithChildren,

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -2,7 +2,6 @@ import useUniqueId from "./hooks/useUniqueId";
 import {
   createElement,
   CSSProperties,
-  ElementType,
   HTMLAttributes,
   PropsWithChildren,
   MouseEvent as ReactMouseEvent,

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -47,7 +47,7 @@ export function PanelResizeHandle({
   tagName: Type = "div",
   ...rest
 }: PanelResizeHandleProps) {
-  const divElementRef = useRef<HTMLDivElement>(null);
+  const elementRef = useRef<HTMLElement>(null);
 
   // Use a ref to guard against users passing inline props
   const callbacksRef = useRef<{
@@ -85,9 +85,9 @@ export function PanelResizeHandle({
   const stopDraggingAndBlur = useCallback(() => {
     // Clicking on the drag handle shouldn't leave it focused;
     // That would cause the PanelGroup to think it was still active.
-    const divElement = divElementRef.current;
-    assert(divElement);
-    divElement.blur();
+    const element = elementRef.current;
+    assert(element);
+    element.blur();
 
     stopDragging();
 
@@ -119,10 +119,10 @@ export function PanelResizeHandle({
       resizeHandler(event);
     };
 
-    const divElement = divElementRef.current;
-    assert(divElement);
+    const element = elementRef.current;
+    assert(element);
 
-    const targetDocument = divElement.ownerDocument;
+    const targetDocument = element.ownerDocument;
 
     targetDocument.body.addEventListener("contextmenu", stopDraggingAndBlur);
     targetDocument.body.addEventListener("mousemove", onMove);
@@ -186,7 +186,7 @@ export function PanelResizeHandle({
         onDragging(true);
       }
     },
-    ref: divElementRef,
+    ref: elementRef,
     role: "separator",
     style: {
       ...style,

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -25,7 +25,7 @@ import { getCursorStyle } from "./utils/cursor";
 
 export type PanelResizeHandleOnDragging = (isDragging: boolean) => void;
 
-export type PanelResizeHandleProps = Omit<HTMLAttributes<ElementType>, "id"> &
+export type PanelResizeHandleProps = Omit<HTMLAttributes<keyof HTMLElementTagNameMap>, "id"> &
   PropsWithChildren<{
     className?: string;
     disabled?: boolean;
@@ -33,7 +33,7 @@ export type PanelResizeHandleProps = Omit<HTMLAttributes<ElementType>, "id"> &
     onDragging?: PanelResizeHandleOnDragging;
     style?: CSSProperties;
     tabIndex?: number;
-    tagName?: ElementType;
+    tagName?: keyof HTMLElementTagNameMap;
   }>;
 
 export function PanelResizeHandle({

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -25,10 +25,8 @@ import { getCursorStyle } from "./utils/cursor";
 
 export type PanelResizeHandleOnDragging = (isDragging: boolean) => void;
 
-type HTMLElementTagName = keyof HTMLElementTagNameMap;
-
 export type PanelResizeHandleProps = Omit<
-  HTMLAttributes<HTMLElementTagName>,
+  HTMLAttributes<keyof HTMLElementTagNameMap>,
   "id"
 > &
   PropsWithChildren<{
@@ -38,7 +36,7 @@ export type PanelResizeHandleProps = Omit<
     onDragging?: PanelResizeHandleOnDragging;
     style?: CSSProperties;
     tabIndex?: number;
-    tagName?: HTMLElementTagName;
+    tagName?: keyof HTMLElementTagNameMap;
   }>;
 
 export function PanelResizeHandle({

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -5,6 +5,7 @@ import {
   HTMLAttributes,
   PropsWithChildren,
   MouseEvent as ReactMouseEvent,
+  ReactNode,
   TouchEvent,
   useCallback,
   useContext,
@@ -24,8 +25,10 @@ import { getCursorStyle } from "./utils/cursor";
 
 export type PanelResizeHandleOnDragging = (isDragging: boolean) => void;
 
+type HTMLElementTagName = keyof HTMLElementTagNameMap;
+
 export type PanelResizeHandleProps = Omit<
-  HTMLAttributes<keyof HTMLElementTagNameMap>,
+  HTMLAttributes<HTMLElementTagName>,
   "id"
 > &
   PropsWithChildren<{
@@ -35,7 +38,7 @@ export type PanelResizeHandleProps = Omit<
     onDragging?: PanelResizeHandleOnDragging;
     style?: CSSProperties;
     tabIndex?: number;
-    tagName?: keyof HTMLElementTagNameMap;
+    tagName?: HTMLElementTagName;
   }>;
 
 export function PanelResizeHandle({
@@ -48,7 +51,7 @@ export function PanelResizeHandle({
   tabIndex = 0,
   tagName: Type = "div",
   ...rest
-}: PanelResizeHandleProps) {
+}: PanelResizeHandleProps): ReactNode {
   const elementRef = useRef<HTMLElement>(null);
 
   // Use a ref to guard against users passing inline props

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -25,7 +25,10 @@ import { getCursorStyle } from "./utils/cursor";
 
 export type PanelResizeHandleOnDragging = (isDragging: boolean) => void;
 
-export type PanelResizeHandleProps = Omit<HTMLAttributes<keyof HTMLElementTagNameMap>, "id"> &
+export type PanelResizeHandleProps = Omit<
+  HTMLAttributes<keyof HTMLElementTagNameMap>,
+  "id"
+> &
   PropsWithChildren<{
     className?: string;
     disabled?: boolean;

--- a/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
+++ b/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
@@ -62,7 +62,7 @@ export function useWindowSplitterResizeHandlerBehavior({
             ? index + 1
             : 0;
 
-          const nextHandle = handles[nextIndex] as HTMLDivElement;
+          const nextHandle = handles[nextIndex] as HTMLElement;
           nextHandle.focus();
 
           break;

--- a/packages/react-resizable-panels/src/utils/dom/getPanelElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelElement.ts
@@ -1,7 +1,7 @@
-export function getPanelElement(id: string): HTMLDivElement | null {
+export function getPanelElement(id: string): HTMLElement | null {
   const element = document.querySelector(`[data-panel-id="${id}"]`);
   if (element) {
-    return element as HTMLDivElement;
+    return element as HTMLElement;
   }
   return null;
 }

--- a/packages/react-resizable-panels/src/utils/dom/getPanelElementsForGroup.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelElementsForGroup.ts
@@ -1,4 +1,4 @@
-export function getPanelElementsForGroup(groupId: string): HTMLDivElement[] {
+export function getPanelElementsForGroup(groupId: string): HTMLElement[] {
   return Array.from(
     document.querySelectorAll(`[data-panel][data-panel-group-id="${groupId}"]`)
   );

--- a/packages/react-resizable-panels/src/utils/dom/getPanelGroupElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelGroupElement.ts
@@ -1,9 +1,9 @@
-export function getPanelGroupElement(id: string): HTMLDivElement | null {
+export function getPanelGroupElement(id: string): HTMLElement | null {
   const element = document.querySelector(
     `[data-panel-group][data-panel-group-id="${id}"]`
   );
   if (element) {
-    return element as HTMLDivElement;
+    return element as HTMLElement;
   }
   return null;
 }

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
@@ -1,9 +1,9 @@
-export function getResizeHandleElement(id: string): HTMLDivElement | null {
+export function getResizeHandleElement(id: string): HTMLElement | null {
   const element = document.querySelector(
     `[data-panel-resize-handle-id="${id}"]`
   );
   if (element) {
-    return element as HTMLDivElement;
+    return element as HTMLElement;
   }
   return null;
 }

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
@@ -1,6 +1,6 @@
 export function getResizeHandleElementsForGroup(
   groupId: string
-): HTMLDivElement[] {
+): HTMLElement[] {
   return Array.from(
     document.querySelectorAll(
       `[data-panel-resize-handle-id][data-panel-group-id="${groupId}"]`


### PR DESCRIPTION
This widens the usage of `HTMLDivElement` to `HTMLElement` throughout.

Also narrows the allowed tag names to actual HTML elements. Closes #251 