### PR TITLE
Replacing document with group panel element

### DIFF
--- a/packages/react-resizable-panels/src/Panel.test.tsx
+++ b/packages/react-resizable-panels/src/Panel.test.tsx
@@ -12,6 +12,7 @@ import { createRef } from "./vendor/react";
 describe("PanelGroup", () => {
   let expectedWarnings: string[] = [];
   let root: Root;
+  let container: HTMLElement;
   let uninstallMockOffsetWidthAndHeight: () => void;
 
   function expectWarning(expectedMessage: string) {
@@ -258,7 +259,7 @@ describe("PanelGroup", () => {
       );
     });
 
-    const element = getPanelElement("panel");
+    const element = getPanelElement("panel", container);
     assert(element);
     expect(element.tabIndex).toBe(123);
     expect(element.getAttribute("data-test-name")).toBe("foo");

--- a/packages/react-resizable-panels/src/PanelGroup.test.tsx
+++ b/packages/react-resizable-panels/src/PanelGroup.test.tsx
@@ -15,6 +15,7 @@ import { createRef } from "./vendor/react";
 describe("PanelGroup", () => {
   let expectedWarnings: string[] = [];
   let root: Root;
+  let container: HTMLElement;
   let uninstallMockOffsetWidthAndHeight: () => void;
 
   function expectWarning(expectedMessage: string) {
@@ -28,7 +29,7 @@ describe("PanelGroup", () => {
     // JSDom doesn't support element sizes
     uninstallMockOffsetWidthAndHeight = mockPanelGroupOffsetWidthAndHeight();
 
-    const container = document.createElement("div");
+    container = document.createElement("div");
     document.body.appendChild(container);
 
     expectedWarnings = [];
@@ -124,7 +125,7 @@ describe("PanelGroup", () => {
       );
     });
 
-    const element = getPanelGroupElement("group");
+    const element = getPanelGroupElement("group", container);
     assert(element);
     expect(element.tabIndex).toBe(123);
     expect(element.getAttribute("data-test-name")).toBe("foo");

--- a/packages/react-resizable-panels/src/PanelGroupContext.ts
+++ b/packages/react-resizable-panels/src/PanelGroupContext.ts
@@ -11,7 +11,7 @@ export type DragState = {
   initialLayout: number[];
 };
 
-export const PanelGroupContext = createContext<{
+export type TPanelGroupContext = {
   collapsePanel: (panelData: PanelData) => void;
   direction: "horizontal" | "vertical";
   dragState: DragState | null;
@@ -30,6 +30,8 @@ export const PanelGroupContext = createContext<{
   startDragging: (dragHandleId: string, event: ResizeEvent) => void;
   stopDragging: () => void;
   unregisterPanel: (panelData: PanelData) => void;
-} | null>(null);
+  panelGroupElement: ParentNode | null;
+};
+export const PanelGroupContext = createContext<TPanelGroupContext | null>(null);
 
 PanelGroupContext.displayName = "PanelGroupContext";

--- a/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
@@ -7,12 +7,12 @@ import { getResizeHandleElement } from "./utils/dom/getResizeHandleElement";
 describe("PanelResizeHandle", () => {
   let expectedWarnings: string[] = [];
   let root: Root;
+  let container: HTMLElement;
 
   beforeEach(() => {
     // @ts-expect-error
     global.IS_REACT_ACT_ENVIRONMENT = true;
-
-    const container = document.createElement("div");
+    container = document.createElement("div");
     document.body.appendChild(container);
 
     expectedWarnings = [];
@@ -59,7 +59,7 @@ describe("PanelResizeHandle", () => {
       );
     });
 
-    const element = getResizeHandleElement("handle");
+    const element = getResizeHandleElement("handle", container);
     assert(element);
     expect(element.tabIndex).toBe(123);
     expect(element.getAttribute("data-test-name")).toBe("foo");

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -74,6 +74,7 @@ export function PanelResizeHandle({
     registerResizeHandle,
     startDragging,
     stopDragging,
+    panelGroupElement,
   } = panelGroupContext;
 
   const resizeHandleId = useUniqueId(idFromProps);
@@ -151,6 +152,7 @@ export function PanelResizeHandle({
     disabled,
     handleId: resizeHandleId,
     resizeHandler,
+    panelGroupElement,
   });
 
   const style: CSSProperties = {

--- a/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
+++ b/packages/react-resizable-panels/src/hooks/useWindowSplitterBehavior.ts
@@ -11,17 +11,19 @@ export function useWindowSplitterResizeHandlerBehavior({
   disabled,
   handleId,
   resizeHandler,
+  panelGroupElement,
 }: {
   disabled: boolean;
   handleId: string;
   resizeHandler: ResizeHandler | null;
+  panelGroupElement: HTMLElement | null;
 }): void {
   useEffect(() => {
-    if (disabled || resizeHandler == null) {
+    if (disabled || resizeHandler == null || panelGroupElement == null) {
       return;
     }
 
-    const handleElement = getResizeHandleElement(handleId);
+    const handleElement = getResizeHandleElement(handleId, panelGroupElement);
     if (handleElement == null) {
       return;
     }
@@ -49,8 +51,15 @@ export function useWindowSplitterResizeHandlerBehavior({
           const groupId = handleElement.getAttribute("data-panel-group-id");
           assert(groupId);
 
-          const handles = getResizeHandleElementsForGroup(groupId);
-          const index = getResizeHandleElementIndex(groupId, handleId);
+          const handles = getResizeHandleElementsForGroup(
+            groupId,
+            panelGroupElement
+          );
+          const index = getResizeHandleElementIndex(
+            groupId,
+            handleId,
+            panelGroupElement
+          );
 
           assert(index !== null);
 
@@ -74,5 +83,5 @@ export function useWindowSplitterResizeHandlerBehavior({
     return () => {
       handleElement.removeEventListener("keydown", onKeyDown);
     };
-  }, [disabled, handleId, resizeHandler]);
+  }, [panelGroupElement, disabled, handleId, resizeHandler]);
 }

--- a/packages/react-resizable-panels/src/utils/calculateDeltaPercentage.ts
+++ b/packages/react-resizable-panels/src/utils/calculateDeltaPercentage.ts
@@ -9,7 +9,8 @@ export function calculateDeltaPercentage(
   dragHandleId: string,
   direction: Direction,
   initialDragState: DragState | null,
-  keyboardResizeBy: number | null
+  keyboardResizeBy: number | null,
+  panelGroupElement: HTMLElement
 ): number {
   if (isKeyDown(event)) {
     const isHorizontal = direction === "horizontal";
@@ -55,7 +56,8 @@ export function calculateDeltaPercentage(
       event,
       dragHandleId,
       direction,
-      initialDragState
+      initialDragState,
+      panelGroupElement
     );
   }
 }

--- a/packages/react-resizable-panels/src/utils/calculateDragOffsetPercentage.ts
+++ b/packages/react-resizable-panels/src/utils/calculateDragOffsetPercentage.ts
@@ -9,11 +9,12 @@ export function calculateDragOffsetPercentage(
   event: ResizeEvent,
   dragHandleId: string,
   direction: Direction,
-  initialDragState: DragState
+  initialDragState: DragState,
+  panelGroupElement: HTMLElement
 ): number {
   const isHorizontal = direction === "horizontal";
 
-  const handleElement = getResizeHandleElement(dragHandleId);
+  const handleElement = getResizeHandleElement(dragHandleId, panelGroupElement);
   assert(handleElement);
 
   const groupId = handleElement.getAttribute("data-panel-group-id");
@@ -23,7 +24,7 @@ export function calculateDragOffsetPercentage(
 
   const cursorPosition = getResizeEventCursorPosition(direction, event);
 
-  const groupElement = getPanelGroupElement(groupId);
+  const groupElement = getPanelGroupElement(groupId, panelGroupElement);
   assert(groupElement);
 
   const groupRect = groupElement.getBoundingClientRect();

--- a/packages/react-resizable-panels/src/utils/determinePivotIndices.ts
+++ b/packages/react-resizable-panels/src/utils/determinePivotIndices.ts
@@ -2,9 +2,14 @@ import { getResizeHandleElementIndex } from "../utils/dom/getResizeHandleElement
 
 export function determinePivotIndices(
   groupId: string,
-  dragHandleId: string
+  dragHandleId: string,
+  panelGroupElement: HTMLElement
 ): [indexBefore: number, indexAfter: number] {
-  const index = getResizeHandleElementIndex(groupId, dragHandleId);
+  const index = getResizeHandleElementIndex(
+    groupId,
+    dragHandleId,
+    panelGroupElement
+  );
 
   return index != null ? [index, index + 1] : [-1, -1];
 }

--- a/packages/react-resizable-panels/src/utils/dom/calculateAvailablePanelSizeInPixels.ts
+++ b/packages/react-resizable-panels/src/utils/dom/calculateAvailablePanelSizeInPixels.ts
@@ -1,8 +1,10 @@
 import { getPanelGroupElement } from "./getPanelGroupElement";
 import { getResizeHandleElementsForGroup } from "./getResizeHandleElementsForGroup";
 
-export function calculateAvailablePanelSizeInPixels(groupId: string): number {
-  const panelGroupElement = getPanelGroupElement(groupId);
+export function calculateAvailablePanelSizeInPixels(
+  groupId: string,
+  panelGroupElement: HTMLElement
+): number {
   if (panelGroupElement == null) {
     return NaN;
   }
@@ -10,7 +12,10 @@ export function calculateAvailablePanelSizeInPixels(groupId: string): number {
   const direction = panelGroupElement.getAttribute(
     "data-panel-group-direction"
   );
-  const resizeHandles = getResizeHandleElementsForGroup(groupId);
+  const resizeHandles = getResizeHandleElementsForGroup(
+    groupId,
+    panelGroupElement
+  );
   if (direction === "horizontal") {
     return (
       panelGroupElement.offsetWidth -

--- a/packages/react-resizable-panels/src/utils/dom/getAvailableGroupSizePixels.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getAvailableGroupSizePixels.ts
@@ -1,16 +1,17 @@
 import { getPanelGroupElement } from "./getPanelGroupElement";
 import { getResizeHandleElementsForGroup } from "./getResizeHandleElementsForGroup";
 
-export function getAvailableGroupSizePixels(groupId: string): number {
-  const panelGroupElement = getPanelGroupElement(groupId);
-  if (panelGroupElement == null) {
-    return NaN;
-  }
-
+export function getAvailableGroupSizePixels(
+  groupId: string,
+  panelGroupElement: HTMLElement
+): number {
   const direction = panelGroupElement.getAttribute(
     "data-panel-group-direction"
   );
-  const resizeHandles = getResizeHandleElementsForGroup(groupId);
+  const resizeHandles = getResizeHandleElementsForGroup(
+    groupId,
+    panelGroupElement
+  );
   if (direction === "horizontal") {
     return (
       panelGroupElement.offsetWidth -

--- a/packages/react-resizable-panels/src/utils/dom/getPanelElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelElement.ts
@@ -1,5 +1,8 @@
-export function getPanelElement(id: string): HTMLElement | null {
-  const element = document.querySelector(`[data-panel-id="${id}"]`);
+export function getPanelElement(
+  id: string,
+  panelGroupElement: HTMLElement
+): HTMLElement | null {
+  const element = panelGroupElement.querySelector(`[data-panel-id="${id}"]`);
   if (element) {
     return element as HTMLElement;
   }

--- a/packages/react-resizable-panels/src/utils/dom/getPanelElementsForGroup.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelElementsForGroup.ts
@@ -1,5 +1,10 @@
-export function getPanelElementsForGroup(groupId: string): HTMLElement[] {
+export function getPanelElementsForGroup(
+  groupId: string,
+  panelGroupElement: HTMLElement
+): HTMLElement[] {
   return Array.from(
-    document.querySelectorAll(`[data-panel][data-panel-group-id="${groupId}"]`)
+    panelGroupElement.querySelectorAll(
+      `[data-panel][data-panel-group-id="${groupId}"]`
+    )
   );
 }

--- a/packages/react-resizable-panels/src/utils/dom/getPanelGroupElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelGroupElement.ts
@@ -1,5 +1,17 @@
-export function getPanelGroupElement(id: string): HTMLElement | null {
-  const element = document.querySelector(
+export function getPanelGroupElement(
+  id: string,
+  rootElement: ParentNode | HTMLElement
+): HTMLElement | null {
+  //If the root element is the PanelGroup
+  if (
+    rootElement instanceof HTMLElement &&
+    (rootElement as HTMLElement)?.dataset?.panelGroupId == id
+  ) {
+    return rootElement as HTMLElement;
+  }
+
+  //Else query children
+  const element = rootElement.querySelector(
     `[data-panel-group][data-panel-group-id="${id}"]`
   );
   if (element) {

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
@@ -1,5 +1,8 @@
-export function getResizeHandleElement(id: string): HTMLElement | null {
-  const element = document.querySelector(
+export function getResizeHandleElement(
+  id: string,
+  panelGroupElement: HTMLElement
+): HTMLElement | null {
+  const element = panelGroupElement.querySelector(
     `[data-panel-resize-handle-id="${id}"]`
   );
   if (element) {

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementIndex.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementIndex.ts
@@ -2,9 +2,10 @@ import { getResizeHandleElementsForGroup } from "./getResizeHandleElementsForGro
 
 export function getResizeHandleElementIndex(
   groupId: string,
-  id: string
+  id: string,
+  panelGroupElement: HTMLElement
 ): number | null {
-  const handles = getResizeHandleElementsForGroup(groupId);
+  const handles = getResizeHandleElementsForGroup(groupId, panelGroupElement);
   const index = handles.findIndex(
     (handle) => handle.getAttribute("data-panel-resize-handle-id") === id
   );

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
@@ -1,8 +1,9 @@
 export function getResizeHandleElementsForGroup(
-  groupId: string
+  groupId: string,
+  panelGroupElement: HTMLElement
 ): HTMLElement[] {
   return Array.from(
-    document.querySelectorAll(
+    panelGroupElement.querySelectorAll(
       `[data-panel-resize-handle-id][data-panel-group-id="${groupId}"]`
     )
   );

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandlePanelIds.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandlePanelIds.ts
@@ -5,10 +5,11 @@ import { getResizeHandleElementsForGroup } from "./getResizeHandleElementsForGro
 export function getResizeHandlePanelIds(
   groupId: string,
   handleId: string,
-  panelsArray: PanelData[]
+  panelsArray: PanelData[],
+  panelGroupElement: HTMLElement
 ): [idBefore: string | null, idAfter: string | null] {
-  const handle = getResizeHandleElement(handleId);
-  const handles = getResizeHandleElementsForGroup(groupId);
+  const handle = getResizeHandleElement(handleId, panelGroupElement);
+  const handles = getResizeHandleElementsForGroup(groupId, panelGroupElement);
   const index = handle ? handles.indexOf(handle) : -1;
 
   const idBefore: string | null = panelsArray[index]?.id ?? null;


### PR DESCRIPTION
As described in #204 the hard dependency on global document can be an problem in some context.

TL;DR; on changes:
**Sets up a ref to the PanelGroup and adds it to the group context**
Prevented some prop drilling of the element.
**Initializes helper hooks with the new group element ref**
**Set up a dependency parameter on the group element in the helper functions**
Decided to make the group element required instead of defaulting to document for testing purposes and for predicability. 
But could be nullable and default to document.
**Tweaked a few tests by adding the root element to the helper function**

Fixes 204 
