### PR TITLE
260 recalcresize

### DIFF
--- a/packages/react-resizable-panels-website/src/routes/examples/Collapsible.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Collapsible.tsx
@@ -177,7 +177,7 @@ const FILES: File[] = FILE_PATHS.map(([path, code]) => {
 const CODE = `
 <PanelGroup direction="horizontal">
   <SideTabBar />
-  <Panel collapsible={true} collapsedSizePixels={35} minSize={10}>
+  <Panel collapsible={true} collapsedSize={35} minSize={10}>
     <SourceBrowser />
   </Panel>
   <PanelResizeHandle />

--- a/packages/react-resizable-panels-website/src/routes/examples/Conditional.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Conditional.tsx
@@ -66,7 +66,13 @@ function Content({
       >
         {showLeftPanel && (
           <>
-            <Panel className={styles.Panel} id="left" minSize={10} order={1}>
+            <Panel
+              collapsible={true}
+              className={styles.Panel}
+              id="left"
+              minSize={10}
+              order={1}
+            >
               <div className={styles.Centered}>left</div>
             </Panel>
             <ResizeHandle className={styles.ResizeHandle} />

--- a/packages/react-resizable-panels/src/utils/serialization.ts
+++ b/packages/react-resizable-panels/src/utils/serialization.ts
@@ -6,7 +6,7 @@ export type PanelGroupState = {
     [panelId: string]: number;
   };
   layout: number[];
-  hash?: Record<string, number>;
+  panelSizes?: Record<string, number>;
 };
 
 function getPanelGroupKey(autoSaveId: string): string {
@@ -85,8 +85,8 @@ export function loadPanelGroupState(
 
   return {
     expandToSizes: state.expandToSizes || {},
-    layout: panels.map(({ id }) => state?.hash?.[id] || 0),
-    hash: state.hash || {},
+    layout: panels.map(({ id }) => state?.panelSizes?.[id] || 0),
+    panelSizes: state.panelSizes || {},
   };
 }
 
@@ -101,8 +101,8 @@ export function savePanelGroupState(
   const oldState = loadPanelGroupState(autoSaveId, panels, storage);
   const newState = {
     expandToSizes: Object.fromEntries(panelSizesBeforeCollapse.entries()),
-    hash: {
-      ...oldState?.hash,
+    panelSizes: {
+      ...oldState?.panelSizes,
       ...panels.reduce<Record<string, number>>((acc, panel, i) => {
         acc[panel.id] = sizes[i] || 0;
         return acc;


### PR DESCRIPTION
This PR is created as a discussion/demo to describe #260 

The PR flattens the panel group state 

**From**
```typescript
{
  "group-1-key": {
    "one,two,three": {layout: [33, 33, 34], expandToSizes: {}},
    "one,two": {layout: [50, 50], expandToSizes: {}},
    "two,three": {layout: [50, 50], expandToSizes: {}},
  }
}
```
**To** 
storing each layout state in a hash
```typescript
{
  "group-1-key": {
    layout: [33, 33, 34], 
    expandToSizes: {},
    hash: {
      one: 33,
      two: 33,
      three: 34
    }
  } satisfies PanelGroupState
}
```

The layouts are then always taken from that hash so a baseline is provided when calculating the new state.
```typescript
layout = panels.map(({ id }) => state?.hash?.[id] || 0)
``` 



When then removing a panel the state might me [33, 33] but that will be recalculated. 

This is a naive implementation, i have not checked all other use-cases, for example what happends if you drag-n-drop / reorder components then this might have to be revisited. 
