### PR TITLE
feat: add defaults for dom util methods

### DIFF
--- a/packages/react-resizable-panels/src/utils/dom/getPanelElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelElement.ts
@@ -1,6 +1,6 @@
 export function getPanelElement(
   id: string,
-  panelGroupElement: HTMLElement
+  panelGroupElement: ParentNode | HTMLElement = document
 ): HTMLElement | null {
   const element = panelGroupElement.querySelector(`[data-panel-id="${id}"]`);
   if (element) {

--- a/packages/react-resizable-panels/src/utils/dom/getPanelElementsForGroup.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelElementsForGroup.ts
@@ -1,6 +1,6 @@
 export function getPanelElementsForGroup(
   groupId: string,
-  panelGroupElement: HTMLElement
+  panelGroupElement: ParentNode | HTMLElement = document
 ): HTMLElement[] {
   return Array.from(
     panelGroupElement.querySelectorAll(

--- a/packages/react-resizable-panels/src/utils/dom/getPanelGroupElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getPanelGroupElement.ts
@@ -1,6 +1,6 @@
 export function getPanelGroupElement(
   id: string,
-  rootElement: ParentNode | HTMLElement
+  rootElement: ParentNode | HTMLElement = document
 ): HTMLElement | null {
   //If the root element is the PanelGroup
   if (

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
@@ -1,6 +1,6 @@
 export function getResizeHandleElement(
   id: string,
-  panelGroupElement: ParentNode
+  panelGroupElement: ParentNode | HTMLElement = document
 ): HTMLElement | null {
   const element = panelGroupElement.querySelector(
     `[data-panel-resize-handle-id="${id}"]`

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementIndex.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementIndex.ts
@@ -3,7 +3,7 @@ import { getResizeHandleElementsForGroup } from "./getResizeHandleElementsForGro
 export function getResizeHandleElementIndex(
   groupId: string,
   id: string,
-  panelGroupElement: ParentNode
+  panelGroupElement: ParentNode | HTMLElement = document
 ): number | null {
   const handles = getResizeHandleElementsForGroup(groupId, panelGroupElement);
   const index = handles.findIndex(

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
@@ -1,6 +1,6 @@
 export function getResizeHandleElementsForGroup(
   groupId: string,
-  panelGroupElement: ParentNode
+  panelGroupElement: ParentNode | HTMLElement = document
 ): HTMLElement[] {
   return Array.from(
     panelGroupElement.querySelectorAll(

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandlePanelIds.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandlePanelIds.ts
@@ -6,7 +6,7 @@ export function getResizeHandlePanelIds(
   groupId: string,
   handleId: string,
   panelsArray: PanelData[],
-  panelGroupElement: ParentNode
+  panelGroupElement: ParentNode | HTMLElement = document
 ): [idBefore: string | null, idAfter: string | null] {
   const handle = getResizeHandleElement(handleId, panelGroupElement);
   const handles = getResizeHandleElementsForGroup(groupId, panelGroupElement);


### PR DESCRIPTION
- Using `document` retains the behaviour from v1.0.7
- Widened type on each to `ParentNode | HTMLElement` (`document` requires `ParentNode`)

Closes  #262