### PR TITLE
BugFix: Global cursor style reset on unmount

### DIFF
--- a/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
@@ -49,12 +49,12 @@ describe("PanelResizeHandle", () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
-    jest.resetModules();
-
     act(() => {
       root.unmount();
     });
+
+    jest.clearAllMocks();
+    jest.resetModules();
 
     expect(expectedWarnings).toHaveLength(0);
   });
@@ -92,6 +92,8 @@ describe("PanelResizeHandle", () => {
         </PanelGroup>
       );
     });
+
+    expect(cursorUtils.resetGlobalCursorStyle).not.toHaveBeenCalled();
 
     act(() => {
       root.unmount();

--- a/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
@@ -7,13 +7,13 @@ import {
   type PanelResizeHandleProps,
 } from ".";
 import { assert } from "./utils/assert";
+import * as cursorUtils from "./utils/cursor";
 import { getResizeHandleElement } from "./utils/dom/getResizeHandleElement";
 import {
   dispatchPointerEvent,
   mockBoundingClientRect,
   verifyAttribute,
 } from "./utils/test-utils";
-import * as cursorUtils from "./utils/cursor";
 
 jest.mock("./utils/cursor", () => ({
   getCursorStyle: jest.fn(),
@@ -50,12 +50,12 @@ describe("PanelResizeHandle", () => {
   });
 
   afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+
     act(() => {
       root.unmount();
     });
-
-    jest.clearAllMocks();
-    jest.resetModules();
 
     expect(expectedWarnings).toHaveLength(0);
   });
@@ -268,7 +268,7 @@ describe("PanelResizeHandle", () => {
       act(() => {
         leftElement.focus();
       });
-      // expect(document.activeElement).toBe(leftElement);
+      expect(document.activeElement).toBe(leftElement);
       verifyAttribute(leftElement, "data-resize-handle-active", "keyboard");
       verifyAttribute(rightElement, "data-resize-handle-active", null);
 
@@ -317,7 +317,7 @@ describe("PanelResizeHandle", () => {
     });
   });
 
-  fit("resets the global cursor style on unmount", () => {
+  it("resets the global cursor style on unmount", () => {
     const onDraggingLeft = jest.fn();
 
     const { leftElement } = setupMockedGroup({

--- a/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
@@ -1,7 +1,11 @@
 import { Root, createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
-import type { PanelResizeHandleProps } from "react-resizable-panels";
-import { Panel, PanelGroup, PanelResizeHandle } from ".";
+import {
+  Panel,
+  PanelGroup,
+  PanelResizeHandle,
+  type PanelResizeHandleProps,
+} from ".";
 import { assert } from "./utils/assert";
 import { getResizeHandleElement } from "./utils/dom/getResizeHandleElement";
 import {
@@ -9,6 +13,12 @@ import {
   mockBoundingClientRect,
   verifyAttribute,
 } from "./utils/test-utils";
+import * as cursorUtils from "./utils/cursor";
+
+jest.mock("./utils/cursor", () => ({
+  ...jest.requireActual("./utils/cursor"),
+  resetGlobalCursorStyle: jest.fn(),
+}));
 
 describe("PanelResizeHandle", () => {
   let expectedWarnings: string[] = [];
@@ -70,6 +80,24 @@ describe("PanelResizeHandle", () => {
     expect(element.tabIndex).toBe(123);
     expect(element.getAttribute("data-test-name")).toBe("foo");
     expect(element.title).toBe("bar");
+  });
+
+  it("resets the global cursor style on unmount", () => {
+    act(() => {
+      root.render(
+        <PanelGroup direction="horizontal">
+          <Panel />
+          <PanelResizeHandle />
+          <Panel />
+        </PanelGroup>
+      );
+    });
+
+    act(() => {
+      root.unmount();
+    });
+
+    expect(cursorUtils.resetGlobalCursorStyle).toHaveBeenCalled();
   });
 
   function setupMockedGroup({

--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -73,7 +73,46 @@ export function registerResizeHandle(
     if (count === 1) {
       ownerDocumentCounts.delete(ownerDocument);
     }
+
+    recalculateIntersectingHandlesAfterUnregister(element);
   };
+}
+
+function recalculateIntersectingHandlesAfterUnregister(
+  excludedElement: HTMLElement
+) {
+  intersectingHandles.splice(0); // Clear current intersecting handles
+
+  registeredResizeHandlers.forEach((data) => {
+    if (data.element !== excludedElement) {
+      const intersects = checkIfHandleIntersects(data);
+      if (intersects) {
+        intersectingHandles.push(data);
+      }
+    }
+  });
+
+  if (intersectingHandles.length > 0) {
+    updateCursor();
+  } else {
+    resetGlobalCursorStyle();
+  }
+}
+
+function checkIfHandleIntersects(data: ResizeHandlerData): boolean {
+  const { element, hitAreaMargins } = data;
+  const rect = element.getBoundingClientRect();
+  const margin = isCoarsePointer ? hitAreaMargins.coarse : hitAreaMargins.fine;
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  // Simplified intersection check with viewport
+  return (
+    rect.left <= viewportWidth + margin &&
+    rect.right >= -margin &&
+    rect.top <= viewportHeight + margin &&
+    rect.bottom >= -margin
+  );
 }
 
 function handlePointerDown(event: ResizeEvent) {

--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -74,6 +74,7 @@ export function registerResizeHandle(
       ownerDocumentCounts.delete(ownerDocument);
     }
 
+    // Reset the global cursor style if necessary
     const dummyEvent = { target: null, x: 0, y: 0 };
     recalculateIntersectingHandles(dummyEvent);
     updateCursor();

--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -74,10 +74,16 @@ export function registerResizeHandle(
       ownerDocumentCounts.delete(ownerDocument);
     }
 
-    // Reset the global cursor style if necessary
-    const dummyEvent = { target: null, x: 0, y: 0 };
-    recalculateIntersectingHandles(dummyEvent);
-    updateCursor();
+    // If the resize handle that is currently unmounting is intersecting with the pointer,
+    // update the global pointer to account for the change
+    if (intersectingHandles.includes(data)) {
+      const index = intersectingHandles.indexOf(data);
+      if (index >= 0) {
+        intersectingHandles.splice(index, 1);
+      }
+
+      updateCursor();
+    }
   };
 }
 

--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -74,45 +74,10 @@ export function registerResizeHandle(
       ownerDocumentCounts.delete(ownerDocument);
     }
 
-    recalculateIntersectingHandlesAfterUnregister(element);
-  };
-}
-
-function recalculateIntersectingHandlesAfterUnregister(
-  excludedElement: HTMLElement
-) {
-  intersectingHandles.splice(0); // Clear current intersecting handles
-
-  registeredResizeHandlers.forEach((data) => {
-    if (data.element !== excludedElement) {
-      const intersects = checkIfHandleIntersects(data);
-      if (intersects) {
-        intersectingHandles.push(data);
-      }
-    }
-  });
-
-  if (intersectingHandles.length > 0) {
+    const dummyEvent = { target: null, x: 0, y: 0 };
+    recalculateIntersectingHandles(dummyEvent);
     updateCursor();
-  } else {
-    resetGlobalCursorStyle();
-  }
-}
-
-function checkIfHandleIntersects(data: ResizeHandlerData): boolean {
-  const { element, hitAreaMargins } = data;
-  const rect = element.getBoundingClientRect();
-  const margin = isCoarsePointer ? hitAreaMargins.coarse : hitAreaMargins.fine;
-  const viewportWidth = window.innerWidth;
-  const viewportHeight = window.innerHeight;
-
-  // Simplified intersection check with viewport
-  return (
-    rect.left <= viewportWidth + margin &&
-    rect.right >= -margin &&
-    rect.top <= viewportHeight + margin &&
-    rect.bottom >= -margin
-  );
+  };
 }
 
 function handlePointerDown(event: ResizeEvent) {


### PR DESCRIPTION
Fixes #308.

This PR updates the `PanelResizeHandle` component to call `resetGlobalCursorStyle` when unmounted. This should prevent the cursor from indefinitely retaining the "resize" style if the component is unmounted as a panel is being resized.

I've tested out these changes locally and they appear to resolve the issue.