### PR TITLE
Fixes TS annotation issue

### DIFF
--- a/packages/react-resizable-panels/src/index.ts
+++ b/packages/react-resizable-panels/src/index.ts
@@ -29,9 +29,7 @@ import type {
   PanelResizeHandleOnDragging,
   PanelResizeHandleProps,
 } from "./PanelResizeHandle";
-import type {
-  PointerHitAreaMargins,
-} from "./PanelResizeHandleRegistry";
+import type { PointerHitAreaMargins } from "./PanelResizeHandleRegistry";
 
 export {
   // TypeScript types

--- a/packages/react-resizable-panels/src/index.ts
+++ b/packages/react-resizable-panels/src/index.ts
@@ -29,6 +29,13 @@ import type {
   PanelResizeHandleOnDragging,
   PanelResizeHandleProps,
 } from "./PanelResizeHandle";
+import type {
+  PointerHitAreaMargins,
+  ResizeHandlerAction,
+  ResizeHandlerData,
+  SetResizeHandlerState,
+} from "./PanelResizeHandleRegistry";
+import type { Direction, ResizeEvent, ResizeHandler } from "./types";
 
 export {
   // TypeScript types
@@ -43,6 +50,13 @@ export {
   PanelProps,
   PanelResizeHandleOnDragging,
   PanelResizeHandleProps,
+  PointerHitAreaMargins,
+  ResizeHandlerAction,
+  ResizeHandlerData,
+  SetResizeHandlerState,
+  Direction,
+  ResizeEvent,
+  ResizeHandler,
 
   // React components
   Panel,

--- a/packages/react-resizable-panels/src/index.ts
+++ b/packages/react-resizable-panels/src/index.ts
@@ -31,11 +31,7 @@ import type {
 } from "./PanelResizeHandle";
 import type {
   PointerHitAreaMargins,
-  ResizeHandlerAction,
-  ResizeHandlerData,
-  SetResizeHandlerState,
 } from "./PanelResizeHandleRegistry";
-import type { Direction, ResizeEvent, ResizeHandler } from "./types";
 
 export {
   // TypeScript types
@@ -51,12 +47,6 @@ export {
   PanelResizeHandleOnDragging,
   PanelResizeHandleProps,
   PointerHitAreaMargins,
-  ResizeHandlerAction,
-  ResizeHandlerData,
-  SetResizeHandlerState,
-  Direction,
-  ResizeEvent,
-  ResizeHandler,
 
   // React components
   Panel,


### PR DESCRIPTION
This fixes `The inferred type of 'ResizableHandle' cannot be named without a reference to 'react-resizable-panels/dist/declarations/src/PanelResizeHandleRegistry'. This is likely not portable. A type annotation is necessary.`

I've exported out types not currently exported from `index.ts`. This resolves the issue that there were internal types not exported resolving annotation issues for `PanelResizeHandle`. I created a build to verify this as well https://www.npmjs.com/package/@akkuma/react-resizable-panels.