### PR TITLE
Do not call onResize on mount if the defaultSize is provided

### DIFF
--- a/packages/react-resizable-panels/src/Panel.test.tsx
+++ b/packages/react-resizable-panels/src/Panel.test.tsx
@@ -779,7 +779,7 @@ describe("PanelGroup", () => {
     });
 
     describe("onResize", () => {
-      it("should be called on mount", () => {
+      it("should be called on mount when default size is not provided", () => {
         let onResizeLeft = jest.fn();
         let onResizeMiddle = jest.fn();
         let onResizeRight = jest.fn();
@@ -803,8 +803,7 @@ describe("PanelGroup", () => {
 
         expect(onResizeLeft).toHaveBeenCalledTimes(1);
         expect(onResizeLeft).toHaveBeenCalledWith(25, undefined);
-        expect(onResizeMiddle).toHaveBeenCalledTimes(1);
-        expect(onResizeMiddle).toHaveBeenCalledWith(50, undefined);
+        expect(onResizeMiddle).not.toHaveBeenCalled();
         expect(onResizeRight).toHaveBeenCalledTimes(1);
         expect(onResizeRight).toHaveBeenCalledWith(25, undefined);
       });

--- a/packages/react-resizable-panels/src/utils/callPanelCallbacks.ts
+++ b/packages/react-resizable-panels/src/utils/callPanelCallbacks.ts
@@ -13,15 +13,15 @@ export function callPanelCallbacks(
     assert(panelData, `Panel data not found for index ${index}`);
 
     const { callbacks, constraints, id: panelId } = panelData;
-    const { collapsedSize = 0, collapsible } = constraints;
+    const { collapsedSize = 0, collapsible, defaultSize } = constraints;
 
     const lastNotifiedSize = panelIdToLastNotifiedSizeMap[panelId];
-    if (lastNotifiedSize == null || size !== lastNotifiedSize) {
+    const isFirstCall = lastNotifiedSize == null;
+    if (isFirstCall || size !== lastNotifiedSize) {
       panelIdToLastNotifiedSizeMap[panelId] = size;
 
       const { onCollapse, onExpand, onResize } = callbacks;
-
-      if (onResize) {
+      if (onResize && (!isFirstCall || defaultSize !== size)) {
         onResize(size, lastNotifiedSize);
       }
 


### PR DESCRIPTION
Actual behavior: `onResize` should be called only, when the actual change happens
Expected behavior: `onResize` should not be called on mount, when the passed size matches the provided default size
Workaround: check on user's side, if the default size is provided and `prevSize` is `undefined`. 
Proposed solution: do the check on the library side