### PR TITLE
Further obfuscate reference to React.useId

### DIFF
--- a/packages/react-resizable-panels/src/vendor/react.ts
+++ b/packages/react-resizable-panels/src/vendor/react.ts
@@ -36,8 +36,8 @@ const {
   useState,
 } = React;
 
-// `toString()` prevents bundlers from trying to `import { useId } from 'react'`
-const useId = (React as any)["useId".toString()] as () => string;
+// `Math.random()` and `.slice(0, 5)` prevents bundlers from trying to `import { useId } from 'react'`
+const useId = (React as any)[`useId${Math.random()}`.slice(0, 5)] as () => string;
 
 const useLayoutEffect_do_not_use_directly = useLayoutEffect;
 

--- a/packages/react-resizable-panels/src/vendor/react.ts
+++ b/packages/react-resizable-panels/src/vendor/react.ts
@@ -37,7 +37,9 @@ const {
 } = React;
 
 // `Math.random()` and `.slice(0, 5)` prevents bundlers from trying to `import { useId } from 'react'`
-const useId = (React as any)[`useId${Math.random()}`.slice(0, 5)] as () => string;
+const useId = (React as any)[
+  `useId${Math.random()}`.slice(0, 5)
+] as () => string;
 
 const useLayoutEffect_do_not_use_directly = useLayoutEffect;
 


### PR DESCRIPTION
Use technique from this comment: https://github.com/mui/material-ui/issues/41190#issuecomment-2040873379 to further obfuscate reference to `React.useId` which causes issue when using `react-resizable-panels` with React <18 and `esbuild` > 0.19.5.

Fixes #381