### PR TITLE
Fix: Resolved startup issue for Example site on Windows environment

### DIFF
--- a/packages/react-resizable-panels-website/package.json
+++ b/packages/react-resizable-panels-website/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "parcel build 'index.html'",
+    "build": "parcel build \"index.html\"",
     "kill-port": "kill-port ${PORT:-1234}",
     "test:e2e": "playwright test",
     "test:e2e:debug": "DEBUG=true playwright test",
-    "watch": "parcel 'index.html'"
+    "watch": "parcel \"index.html\""
   },
   "dependencies": {
     "@codemirror/lang-css": "latest",


### PR DESCRIPTION
Updated the build and watch npm scripts in the package.json of the react-resizable-panels-website package to make it work in a Windows environment. These changes were based on the package.json from the react-resizable-panels package.

It would be great if it also works on other environments like Mac.
