### PR TITLE
Before stack comparison, check if target element is in document

### DIFF
--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -197,6 +197,7 @@ function recalculateIntersectingHandles({
       // and the element that was actually clicked/touched
       if (
         targetElement !== null &&
+        document.contains(targetElement) &&
         dragHandleElement !== targetElement &&
         !dragHandleElement.contains(targetElement) &&
         !targetElement.contains(dragHandleElement) &&


### PR DESCRIPTION
Fixes #409 

Don't feel pressured to merge, but I figured that the solution is fairly simple so I implemented it myself.