### PR TITLE
Add flexible tagName support to PanelProps

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -54,10 +54,9 @@ export type ImperativePanelHandle = {
   resize: (size: number) => void;
 };
 
-export type PanelProps = Omit<
-  HTMLAttributes<keyof HTMLElementTagNameMap>,
-  "id" | "onResize"
-> &
+export type PanelProps<
+  T extends keyof HTMLElementTagNameMap = keyof HTMLElementTagNameMap,
+> = Omit<HTMLAttributes<HTMLElementTagNameMap[T]>, "id" | "onResize"> &
   PropsWithChildren<{
     className?: string;
     collapsedSize?: number | undefined;
@@ -71,7 +70,7 @@ export type PanelProps = Omit<
     onResize?: PanelOnResize;
     order?: number;
     style?: object;
-    tagName?: keyof HTMLElementTagNameMap;
+    tagName?: T;
   }>;
 
 export function PanelWithForwardedRef({


### PR DESCRIPTION
related to (#407)

Instead of fixing the `tagName` type to `keyof HTMLElementTagNameMap`, it has been made flexible by using a generic type.
This allows TypeScript to better infer `event` object types like handleDrop when a specific tagName is provided in the component.

```jsx
<Panel
    onDrop={(e: DragEvent<HTMLDivElement>) => {
      if (e.currentTarget.contains(e.relatedTarget)) return;
    }}
    className={styles.PanelRow}
    defaultSize={20}
    minSize={10}
    tagName="div"
  >
    <div className={styles.Centered}>left</div>
</Panel>

```