### PR TITLE
Add 'hover' state Tailwind class using data attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This likely means that you haven't applied any CSS to style the resize handles. 
 
 ```tsx
 // Tailwind example
-<PanelResizeHandle className="w-2 bg-blue-800" />
+<PanelResizeHandle className="w-2 bg-blue-600 data-[resize-handle-state=hover]:bg-blue-800" />
 ```
 
 ### How can I use persistent layouts with SSR?


### PR DESCRIPTION
Resize action is visible before hitting the resize handle, so cursor change is triggered while `hover:bg-xxx` not. This makes sure the UI changes resize handle background as soon as the cursor shows "resizable"