### PR TITLE
Used dir prop of PanelGroup for rtl support instead of document.dir

### DIFF
--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -648,9 +648,10 @@ function PanelGroupWithForwardedRef({
 
       // Support RTL layouts
       const isHorizontal = direction === "horizontal";
-      if (document.dir === "rtl" && isHorizontal) {
+      const isElmentsRtl = (rest.dir ?? document.dir) === "rtl";
+      if (isHorizontal && isElmentsRtl) {
         delta = -delta;
-      }
+      };
 
       const panelConstraints = panelDataArray.map(
         (panelData) => panelData.constraints


### PR DESCRIPTION
This allow us to use this component in scenarios where PanelGroup is used as a component in an application where you don't have access to document.dir in order to change it for any reason, there is already a dir prop as it is standard HTMLElement prop we just have to use it instead of relying on document.dir which is not a good practice at all, one may choose to apply dir at any level below document to an element and its children, for example:

* story book component
* components with dir=rtl and ltr side by side in a single page
* ...

thanks for awesome library