### PR TITLE
Replace innerHtml with insertRule

### DIFF
--- a/packages/react-resizable-panels/src/utils/cursor.ts
+++ b/packages/react-resizable-panels/src/utils/cursor.ts
@@ -99,5 +99,5 @@ export function setGlobalCursorStyle(
     document.head.appendChild(styleElement);
   }
 
-  styleElement.innerHTML = `*{cursor: ${style}!important;}`;
+  styleElement.sheet?.insertRule(`*{cursor: ${style}!important;}`)
 }


### PR DESCRIPTION
The use of `.innerHTML` causes issues for hosts that have opted in to [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API). Because `.innerHTML` can act as a vector for DOM-XSS attacks, websites might lock it down with Trusted Types, causing the specific line to throw a runtime error.
 
In the case of this specific library, the `.innerHTML` call could just as easily be replaced with inserting a CSS rule, as follows:
```
styleElement.sheet?.insertRule(`*{cursor: ${style}!important;}`)
```
 
Note that to satisfy TypeScript, null-coalescing is added to the `.sheet` access. However, when a style element is attached to the DOM, that `.sheet` property should never be undefined.