### PR TITLE
Use group+panel ID for panel HTML element ID to avoid duplicate eleme…

### DIFF
--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -235,7 +235,7 @@ export function PanelWithForwardedRef({
 
     children,
     className: classNameFromProps,
-    id: idFromProps,
+    id: `${groupId}-${panelId}`,
     style: {
       ...style,
       ...styleFromProps,


### PR DESCRIPTION
In cases where a custom ID is passed for a panel (commonly done when conditionally rendering) the documentation suggests the ID only has to be unique within a group, and shows an example with a fixed string `id` value.

This causes invalid markup if the same ID is used in two groups, for instance if the `PanelGroup` is used in a shared component that renders in two places.

![image](https://github.com/user-attachments/assets/249341b9-387c-476d-b86a-43870b538972)

Attaching the group ID here will ensure we write unique IDs to the DOM.