### PR TITLE
Minor code cleanup: data attributes, `AbortController`

### DIFF
--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -44,7 +44,6 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 - `setItem: (name: string, value: string) => void`
 
 `PanelGroup` components also expose an imperative API for manual resizing:
-
 | method                        | description                                                      |
 | :---------------------------- | :--------------------------------------------------------------- |
 | `getId(): string`             | Gets the panel group's ID.                                       |
@@ -73,7 +72,6 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 <sup>1</sup>: If any `Panel` has an `onResize` callback, the `order` prop should be provided for all `Panel`s.
 
 `Panel` components also expose an imperative API for manual resizing:
-
 | method                   | description                                                                        |
 | :----------------------- | :--------------------------------------------------------------------------------- |
 | `collapse()`             | If panel is `collapsible`, collapse it fully.                                      |
@@ -87,17 +85,16 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 ### `PanelResizeHandle`
 
-| prop              | type                                          | description                                                                     |
-| :---------------- | :-------------------------------------------- | :------------------------------------------------------------------------------ |
-| `children`        | `?ReactNode`                                  | Custom drag UI; can be any arbitrary React element(s)                           |
-| `className`       | `?string`                                     | Class name to attach to root element                                            |
-| `hitAreaMargins`  | `?{ coarse: number = 15; fine: number = 5; }` | Allow this much margin when determining resizable handle hit detection          |
-| `disabled`        | `?boolean`                                    | Disable drag handle                                                             |
-| `id`              | `?string`                                     | Resize handle id (unique within group); falls back to `useId` when not provided |
-| `onDragging`      | `?(isDragging: boolean) => void`              | Called when group layout changes                                                |
-| `style`           | `?CSSProperties`                              | CSS style to attach to root element                                             |
-| `tagName`         | `?string = "div"`                             | HTML element tag name for root element                                          |
-| `propagateEvents` | `?boolean`                                    | Propagate pointer events (usually are stopped to support hitAreaMargins)        |
+| prop             | type                                          | description                                                                     |
+| :--------------- | :-------------------------------------------- | :------------------------------------------------------------------------------ |
+| `children`       | `?ReactNode`                                  | Custom drag UI; can be any arbitrary React element(s)                           |
+| `className`      | `?string`                                     | Class name to attach to root element                                            |
+| `hitAreaMargins` | `?{ coarse: number = 15; fine: number = 5; }` | Allow this much margin when determining resizable handle hit detection          |
+| `disabled`       | `?boolean`                                    | Disable drag handle                                                             |
+| `id`             | `?string`                                     | Resize handle id (unique within group); falls back to `useId` when not provided |
+| `onDragging`     | `?(isDragging: boolean) => void`              | Called when group layout changes                                                |
+| `style`          | `?CSSProperties`                              | CSS style to attach to root element                                             |
+| `tagName`        | `?string = "div"`                             | HTML element tag name for root element                                          |
 
 ---
 

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -44,6 +44,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 - `setItem: (name: string, value: string) => void`
 
 `PanelGroup` components also expose an imperative API for manual resizing:
+
 | method                        | description                                                      |
 | :---------------------------- | :--------------------------------------------------------------- |
 | `getId(): string`             | Gets the panel group's ID.                                       |
@@ -72,6 +73,7 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 <sup>1</sup>: If any `Panel` has an `onResize` callback, the `order` prop should be provided for all `Panel`s.
 
 `Panel` components also expose an imperative API for manual resizing:
+
 | method                   | description                                                                        |
 | :----------------------- | :--------------------------------------------------------------------------------- |
 | `collapse()`             | If panel is `collapsible`, collapse it fully.                                      |
@@ -85,16 +87,17 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 ### `PanelResizeHandle`
 
-| prop             | type                                          | description                                                                     |
-| :--------------- | :-------------------------------------------- | :------------------------------------------------------------------------------ |
-| `children`       | `?ReactNode`                                  | Custom drag UI; can be any arbitrary React element(s)                           |
-| `className`      | `?string`                                     | Class name to attach to root element                                            |
-| `hitAreaMargins` | `?{ coarse: number = 15; fine: number = 5; }` | Allow this much margin when determining resizable handle hit detection          |
-| `disabled`       | `?boolean`                                    | Disable drag handle                                                             |
-| `id`             | `?string`                                     | Resize handle id (unique within group); falls back to `useId` when not provided |
-| `onDragging`     | `?(isDragging: boolean) => void`              | Called when group layout changes                                                |
-| `style`          | `?CSSProperties`                              | CSS style to attach to root element                                             |
-| `tagName`        | `?string = "div"`                             | HTML element tag name for root element                                          |
+| prop              | type                                          | description                                                                     |
+| :---------------- | :-------------------------------------------- | :------------------------------------------------------------------------------ |
+| `children`        | `?ReactNode`                                  | Custom drag UI; can be any arbitrary React element(s)                           |
+| `className`       | `?string`                                     | Class name to attach to root element                                            |
+| `hitAreaMargins`  | `?{ coarse: number = 15; fine: number = 5; }` | Allow this much margin when determining resizable handle hit detection          |
+| `disabled`        | `?boolean`                                    | Disable drag handle                                                             |
+| `id`              | `?string`                                     | Resize handle id (unique within group); falls back to `useId` when not provided |
+| `onDragging`      | `?(isDragging: boolean) => void`              | Called when group layout changes                                                |
+| `style`           | `?CSSProperties`                              | CSS style to attach to root element                                             |
+| `tagName`         | `?string = "div"`                             | HTML element tag name for root element                                          |
+| `propagateEvents` | `?boolean`                                    | Propagate pointer events (usually are stopped to support hitAreaMargins)        |
 
 ---
 

--- a/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
@@ -6,6 +6,7 @@ import {
   PanelResizeHandle,
   type PanelResizeHandleProps,
 } from ".";
+import { RESIZE_HANDLE_ATTRIBUTES } from "./constants";
 import { assert } from "./utils/assert";
 import * as cursorUtils from "./utils/cursor";
 import { getResizeHandleElement } from "./utils/dom/getResizeHandleElement";
@@ -262,92 +263,88 @@ describe("PanelResizeHandle", () => {
       const { leftElement, rightElement } = setupMockedGroup();
 
       verifyAttribute(leftElement, "data-panel-group-id", "test-group");
-      verifyAttribute(leftElement, "data-resize-handle", "");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.root, "");
       verifyAttribute(leftElement, "data-panel-group-direction", "horizontal");
-      verifyAttribute(leftElement, "data-panel-resize-handle-enabled", "true");
-      verifyAttribute(
-        leftElement,
-        "data-panel-resize-handle-id",
-        "handle-left"
-      );
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.enabled, "true");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.id, "handle-left");
 
       verifyAttribute(rightElement, "data-panel-group-id", "test-group");
-      verifyAttribute(rightElement, "data-resize-handle", "");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.root, "");
       verifyAttribute(rightElement, "data-panel-group-direction", "horizontal");
-      verifyAttribute(rightElement, "data-panel-resize-handle-enabled", "true");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.enabled, "true");
       verifyAttribute(
         rightElement,
-        "data-panel-resize-handle-id",
+        RESIZE_HANDLE_ATTRIBUTES.id,
         "handle-right"
       );
     });
 
-    it("should update data-resize-handle-active and data-resize-handle-state when dragging starts/stops", () => {
+    it(`should update ${RESIZE_HANDLE_ATTRIBUTES.active} and ${RESIZE_HANDLE_ATTRIBUTES.state} when dragging starts/stops`, () => {
       const { leftElement, rightElement } = setupMockedGroup();
-      verifyAttribute(leftElement, "data-resize-handle-active", null);
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
-      verifyAttribute(leftElement, "data-resize-handle-state", "inactive");
-      verifyAttribute(rightElement, "data-resize-handle-state", "inactive");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.state, "inactive");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.state, "inactive");
 
       act(() => {
         dispatchPointerEvent("pointermove", leftElement);
       });
-      verifyAttribute(leftElement, "data-resize-handle-active", null);
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
-      verifyAttribute(leftElement, "data-resize-handle-state", "hover");
-      verifyAttribute(rightElement, "data-resize-handle-state", "inactive");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.state, "hover");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.state, "inactive");
 
       act(() => {
         dispatchPointerEvent("pointerdown", leftElement);
       });
-      verifyAttribute(leftElement, "data-resize-handle-active", "pointer");
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
-      verifyAttribute(leftElement, "data-resize-handle-state", "drag");
-      verifyAttribute(rightElement, "data-resize-handle-state", "inactive");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, "pointer");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.state, "drag");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.state, "inactive");
 
       act(() => {
         dispatchPointerEvent("pointermove", leftElement);
       });
-      verifyAttribute(leftElement, "data-resize-handle-active", "pointer");
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
-      verifyAttribute(leftElement, "data-resize-handle-state", "drag");
-      verifyAttribute(rightElement, "data-resize-handle-state", "inactive");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, "pointer");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.state, "drag");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.state, "inactive");
 
       act(() => {
         dispatchPointerEvent("pointerup", leftElement);
       });
-      verifyAttribute(leftElement, "data-resize-handle-active", null);
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
-      verifyAttribute(leftElement, "data-resize-handle-state", "hover");
-      verifyAttribute(rightElement, "data-resize-handle-state", "inactive");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.state, "hover");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.state, "inactive");
 
       act(() => {
         dispatchPointerEvent("pointermove", rightElement);
       });
-      verifyAttribute(leftElement, "data-resize-handle-active", null);
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
-      verifyAttribute(leftElement, "data-resize-handle-state", "inactive");
-      verifyAttribute(rightElement, "data-resize-handle-state", "hover");
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.state, "inactive");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.state, "hover");
     });
 
-    it("should update data-resize-handle-active when focused", () => {
+    it(`should update ${RESIZE_HANDLE_ATTRIBUTES.active} when focused`, () => {
       const { leftElement, rightElement } = setupMockedGroup();
-      verifyAttribute(leftElement, "data-resize-handle-active", null);
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
 
       act(() => {
         leftElement.focus();
       });
       expect(document.activeElement).toBe(leftElement);
-      verifyAttribute(leftElement, "data-resize-handle-active", "keyboard");
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, "keyboard");
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
 
       act(() => {
         leftElement.blur();
       });
       expect(document.activeElement).not.toBe(leftElement);
-      verifyAttribute(leftElement, "data-resize-handle-active", null);
-      verifyAttribute(rightElement, "data-resize-handle-active", null);
+      verifyAttribute(leftElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
+      verifyAttribute(rightElement, RESIZE_HANDLE_ATTRIBUTES.active, null);
     });
   });
 
@@ -363,7 +360,9 @@ describe("PanelResizeHandle", () => {
         );
       });
 
-      const element = container.querySelector("[data-resize-handle]");
+      const element = container.querySelector(
+        `[${RESIZE_HANDLE_ATTRIBUTES.root}]`
+      );
 
       expect(element).not.toBeNull();
       expect(element?.getAttribute("id")).toBe("explicit-id");
@@ -380,7 +379,9 @@ describe("PanelResizeHandle", () => {
         );
       });
 
-      const element = container.querySelector("[data-resize-handle]");
+      const element = container.querySelector(
+        `[${RESIZE_HANDLE_ATTRIBUTES.root}]`
+      );
 
       expect(element).not.toBeNull();
       expect(element?.getAttribute("id")).toBeNull();

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -46,7 +46,6 @@ export type PanelResizeHandleProps = Omit<
     style?: CSSProperties;
     tabIndex?: number;
     tagName?: keyof HTMLElementTagNameMap;
-    propagateEvents?: boolean;
   }>;
 
 export function PanelResizeHandle({
@@ -64,7 +63,6 @@ export function PanelResizeHandle({
   style: styleFromProps = {},
   tabIndex = 0,
   tagName: Type = "div",
-  propagateEvents = false,
   ...rest
 }: PanelResizeHandleProps): ReactElement {
   const elementRef = useRef<HTMLElement>(null);
@@ -264,7 +262,6 @@ export function PanelResizeHandle({
     [RESIZE_HANDLE_ATTRIBUTES.state]: state,
     [RESIZE_HANDLE_ATTRIBUTES.enabled]: !disabled,
     [RESIZE_HANDLE_ATTRIBUTES.id]: resizeHandleId,
-    [RESIZE_HANDLE_ATTRIBUTES.propagateEvents]: propagateEvents || undefined,
   });
 }
 

--- a/packages/react-resizable-panels/src/PanelResizeHandle.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.ts
@@ -1,3 +1,15 @@
+import {
+  createElement,
+  CSSProperties,
+  HTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { RESIZE_HANDLE_ATTRIBUTES } from "./constants";
 import useIsomorphicLayoutEffect from "./hooks/useIsomorphicEffect";
 import useUniqueId from "./hooks/useUniqueId";
 import { useWindowSplitterResizeHandlerBehavior } from "./hooks/useWindowSplitterBehavior";
@@ -12,17 +24,6 @@ import {
   ResizeHandlerAction,
 } from "./PanelResizeHandleRegistry";
 import { assert } from "./utils/assert";
-import {
-  createElement,
-  CSSProperties,
-  HTMLAttributes,
-  PropsWithChildren,
-  ReactElement,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
 
 export type PanelResizeHandleOnDragging = (isDragging: boolean) => void;
 export type ResizeHandlerState = "drag" | "hover" | "inactive";
@@ -45,6 +46,7 @@ export type PanelResizeHandleProps = Omit<
     style?: CSSProperties;
     tabIndex?: number;
     tagName?: keyof HTMLElementTagNameMap;
+    propagateEvents?: boolean;
   }>;
 
 export function PanelResizeHandle({
@@ -62,6 +64,7 @@ export function PanelResizeHandle({
   style: styleFromProps = {},
   tabIndex = 0,
   tagName: Type = "div",
+  propagateEvents = false,
   ...rest
 }: PanelResizeHandleProps): ReactElement {
   const elementRef = useRef<HTMLElement>(null);
@@ -145,53 +148,54 @@ export function PanelResizeHandle({
       isActive: boolean,
       event: ResizeEvent | null
     ) => {
-      if (isActive) {
-        switch (action) {
-          case "down": {
-            setState("drag");
-
-            didMove = false;
-
-            assert(event, 'Expected event to be defined for "down" action');
-
-            startDragging(resizeHandleId, event);
-
-            const { onDragging, onPointerDown } = callbacksRef.current;
-            onDragging?.(true);
-            onPointerDown?.();
-            break;
-          }
-          case "move": {
-            const { state } = committedValuesRef.current;
-
-            didMove = true;
-
-            if (state !== "drag") {
-              setState("hover");
-            }
-
-            assert(event, 'Expected event to be defined for "move" action');
-
-            resizeHandler(event);
-            break;
-          }
-          case "up": {
-            setState("hover");
-
-            stopDragging();
-
-            const { onClick, onDragging, onPointerUp } = callbacksRef.current;
-            onDragging?.(false);
-            onPointerUp?.();
-
-            if (!didMove) {
-              onClick?.();
-            }
-            break;
-          }
-        }
-      } else {
+      if (!isActive) {
         setState("inactive");
+        return;
+      }
+
+      switch (action) {
+        case "down": {
+          setState("drag");
+
+          didMove = false;
+
+          assert(event, 'Expected event to be defined for "down" action');
+
+          startDragging(resizeHandleId, event);
+
+          const { onDragging, onPointerDown } = callbacksRef.current;
+          onDragging?.(true);
+          onPointerDown?.();
+          break;
+        }
+        case "move": {
+          const { state } = committedValuesRef.current;
+
+          didMove = true;
+
+          if (state !== "drag") {
+            setState("hover");
+          }
+
+          assert(event, 'Expected event to be defined for "move" action');
+
+          resizeHandler(event);
+          break;
+        }
+        case "up": {
+          setState("hover");
+
+          stopDragging();
+
+          const { onClick, onDragging, onPointerUp } = callbacksRef.current;
+          onDragging?.(false);
+          onPointerUp?.();
+
+          if (!didMove) {
+            onClick?.();
+          }
+          break;
+        }
       }
     };
 
@@ -254,12 +258,13 @@ export function PanelResizeHandle({
     // CSS selectors
     "data-panel-group-direction": direction,
     "data-panel-group-id": groupId,
-    "data-resize-handle": "",
-    "data-resize-handle-active":
+    [RESIZE_HANDLE_ATTRIBUTES.root]: "",
+    [RESIZE_HANDLE_ATTRIBUTES.active]:
       state === "drag" ? "pointer" : isFocused ? "keyboard" : undefined,
-    "data-resize-handle-state": state,
-    "data-panel-resize-handle-enabled": !disabled,
-    "data-panel-resize-handle-id": resizeHandleId,
+    [RESIZE_HANDLE_ATTRIBUTES.state]: state,
+    [RESIZE_HANDLE_ATTRIBUTES.enabled]: !disabled,
+    [RESIZE_HANDLE_ATTRIBUTES.id]: resizeHandleId,
+    [RESIZE_HANDLE_ATTRIBUTES.propagateEvents]: propagateEvents || undefined,
   });
 }
 

--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -104,22 +104,8 @@ function handlePointerDown(event: PointerEvent) {
   if (intersectingHandles.length > 0) {
     updateResizeHandlerStates("down", event);
 
-    let propagateEvents: boolean | undefined;
-    if (target instanceof HTMLElement || target instanceof SVGElement) {
-      const resizeHandleElement = target.hasAttribute(
-        RESIZE_HANDLE_ATTRIBUTES.root
-      )
-        ? target
-        : target.closest(`[${RESIZE_HANDLE_ATTRIBUTES.root}]`);
-      propagateEvents = resizeHandleElement?.hasAttribute(
-        RESIZE_HANDLE_ATTRIBUTES.propagateEvents
-      );
-    }
-
-    if (!propagateEvents) {
-      event.preventDefault();
-      event.stopPropagation();
-    }
+    event.preventDefault();
+    event.stopPropagation();
   }
 }
 

--- a/packages/react-resizable-panels/src/constants.ts
+++ b/packages/react-resizable-panels/src/constants.ts
@@ -1,1 +1,10 @@
 export const PRECISION = 10;
+
+export const RESIZE_HANDLE_ATTRIBUTES = {
+  root: "data-resize-handle",
+  active: "data-resize-handle-active",
+  state: "data-resize-handle-state",
+  enabled: "data-panel-resize-handle-enabled",
+  id: "data-panel-resize-handle-id",
+  propagateEvents: "data-resize-handle-propagate-events",
+} as const;

--- a/packages/react-resizable-panels/src/constants.ts
+++ b/packages/react-resizable-panels/src/constants.ts
@@ -6,5 +6,4 @@ export const RESIZE_HANDLE_ATTRIBUTES = {
   state: "data-resize-handle-state",
   enabled: "data-panel-resize-handle-enabled",
   id: "data-panel-resize-handle-id",
-  propagateEvents: "data-resize-handle-propagate-events",
 } as const;

--- a/packages/react-resizable-panels/src/hooks/useWindowSplitterPanelGroupBehavior.ts
+++ b/packages/react-resizable-panels/src/hooks/useWindowSplitterPanelGroupBehavior.ts
@@ -1,4 +1,6 @@
 import { isDevelopment } from "#is-development";
+import { RefObject, useEffect, useRef } from "react";
+import { RESIZE_HANDLE_ATTRIBUTES } from "../constants";
 import { PanelData } from "../Panel";
 import { Direction } from "../types";
 import { adjustLayoutByDelta } from "../utils/adjustLayoutByDelta";
@@ -9,7 +11,6 @@ import { getPanelGroupElement } from "../utils/dom/getPanelGroupElement";
 import { getResizeHandleElementsForGroup } from "../utils/dom/getResizeHandleElementsForGroup";
 import { getResizeHandlePanelIds } from "../utils/dom/getResizeHandlePanelIds";
 import { fuzzyNumbersEqual } from "../utils/numbers/fuzzyNumbersEqual";
-import { RefObject, useEffect, useRef } from "react";
 import useIsomorphicLayoutEffect from "./useIsomorphicEffect";
 
 // https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
@@ -115,7 +116,7 @@ export function useWindowSplitterPanelGroupBehavior({
     assert(handles, `No resize handles found for group id "${groupId}"`);
 
     const cleanupFunctions = handles.map((handle) => {
-      const handleId = handle.getAttribute("data-panel-resize-handle-id");
+      const handleId = handle.getAttribute(RESIZE_HANDLE_ATTRIBUTES.id);
       assert(handleId, `Resize handle element has no handle id attribute`);
 
       const [idBefore, idAfter] = getResizeHandlePanelIds(

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElement.ts
@@ -1,8 +1,12 @@
+import { RESIZE_HANDLE_ATTRIBUTES } from "../../constants";
+
 export function getResizeHandleElement(
   id: string,
   scope: ParentNode | HTMLElement = document
 ): HTMLElement | null {
-  const element = scope.querySelector(`[data-panel-resize-handle-id="${id}"]`);
+  const element = scope.querySelector(
+    `[${RESIZE_HANDLE_ATTRIBUTES.id}="${id}"]`
+  );
   if (element) {
     return element as HTMLElement;
   }

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementIndex.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementIndex.ts
@@ -1,3 +1,4 @@
+import { RESIZE_HANDLE_ATTRIBUTES } from "../../constants";
 import { getResizeHandleElementsForGroup } from "./getResizeHandleElementsForGroup";
 
 export function getResizeHandleElementIndex(
@@ -7,7 +8,7 @@ export function getResizeHandleElementIndex(
 ): number | null {
   const handles = getResizeHandleElementsForGroup(groupId, scope);
   const index = handles.findIndex(
-    (handle) => handle.getAttribute("data-panel-resize-handle-id") === id
+    (handle) => handle.getAttribute(RESIZE_HANDLE_ATTRIBUTES.id) === id
   );
   return index ?? null;
 }

--- a/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
+++ b/packages/react-resizable-panels/src/utils/dom/getResizeHandleElementsForGroup.ts
@@ -1,10 +1,12 @@
+import { RESIZE_HANDLE_ATTRIBUTES } from "../../constants";
+
 export function getResizeHandleElementsForGroup(
   groupId: string,
   scope: ParentNode | HTMLElement = document
 ): HTMLElement[] {
   return Array.from(
     scope.querySelectorAll(
-      `[data-panel-resize-handle-id][data-panel-group-id="${groupId}"]`
+      `[${RESIZE_HANDLE_ATTRIBUTES.id}][data-panel-group-id="${groupId}"]`
     )
   );
 }

--- a/packages/react-resizable-panels/src/utils/test-utils.ts
+++ b/packages/react-resizable-panels/src/utils/test-utils.ts
@@ -1,3 +1,4 @@
+import { RESIZE_HANDLE_ATTRIBUTES } from "../constants";
 import { assert } from "./assert";
 
 const util = require("util");
@@ -98,7 +99,7 @@ export function mockPanelGroupOffsetWidthAndHeight(
   Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
     configurable: true,
     get: function () {
-      if (this.hasAttribute("data-resize-handle")) {
+      if (this.hasAttribute(RESIZE_HANDLE_ATTRIBUTES.root)) {
         return 0;
       } else if (this.hasAttribute("data-panel-group")) {
         return mockHeight;
@@ -109,7 +110,7 @@ export function mockPanelGroupOffsetWidthAndHeight(
   Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
     configurable: true,
     get: function () {
-      if (this.hasAttribute("data-resize-handle")) {
+      if (this.hasAttribute(RESIZE_HANDLE_ATTRIBUTES.root)) {
         return 0;
       } else if (this.hasAttribute("data-panel-group")) {
         return mockWidth;


### PR DESCRIPTION
Non-controversial portions of #467 (cc @OhadC)

* Attributes as const
* use `AbortController` for `updateListeners` (avoid the need to call `removeEventListener` on each element)
* Add & Update usage for all resize handle related attributes
