### PR TITLE
Attach handlePointerUp to ownerDocument body

### DIFF
--- a/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
@@ -31,6 +31,7 @@ describe("PanelResizeHandle", () => {
   beforeEach(() => {
     // @ts-expect-error
     global.IS_REACT_ACT_ENVIRONMENT = true;
+
     container = document.createElement("div");
     document.body.appendChild(container);
 
@@ -259,23 +260,26 @@ describe("PanelResizeHandle", () => {
     });
   });
 
+  describe("portals and child windows", () => {
+    test("should add the pointerup event to the separate document NOT the main document", () => {
+      act(() => {
+        root.unmount();
+      });
 
-  describe("event handlers when rendered in a separate document", () => {
-    let separateWindowDocument: Document;
-    beforeEach(() => {
-      // @ts-expect-error
-      global.IS_REACT_ACT_ENVIRONMENT = true;
+      const separateWindowDocument =
+        document.implementation.createHTMLDocument();
 
-      separateWindowDocument = document.implementation.createHTMLDocument();
       container = separateWindowDocument.createElement("div");
-      separateWindowDocument.body.appendChild(container);
-      jest.spyOn(separateWindowDocument.body,"addEventListener");
-      jest.spyOn(document.body,"addEventListener");
-      expectedWarnings = [];
-      root = createRoot(container);
-    });
 
-    it("should add the pointerup event to the separate document NOT the main document", () => {
+      separateWindowDocument.body.appendChild(container);
+
+      vi.spyOn(separateWindowDocument.body, "addEventListener");
+      vi.spyOn(document.body, "addEventListener");
+
+      expectedWarnings = [];
+
+      root = createRoot(container);
+
       const { leftElement } = setupMockedGroup();
 
       act(() => {
@@ -283,12 +287,14 @@ describe("PanelResizeHandle", () => {
         dispatchPointerEvent("pointerup", leftElement);
       });
 
-      expect(separateWindowDocument.body.addEventListener).toHaveBeenCalledWith("pointerup", expect.anything(), expect.anything());
+      expect(separateWindowDocument.body.addEventListener).toHaveBeenCalledWith(
+        "pointerup",
+        expect.anything(),
+        expect.anything()
+      );
       expect(document.body.addEventListener).not.toHaveBeenCalled();
-
     });
   });
-
 
   describe("data attributes", () => {
     test("should initialize with the correct props based attributes", () => {

--- a/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
+++ b/packages/react-resizable-panels/src/PanelResizeHandle.test.tsx
@@ -259,6 +259,37 @@ describe("PanelResizeHandle", () => {
     });
   });
 
+
+  describe("event handlers when rendered in a separate document", () => {
+    let separateWindowDocument: Document;
+    beforeEach(() => {
+      // @ts-expect-error
+      global.IS_REACT_ACT_ENVIRONMENT = true;
+
+      separateWindowDocument = document.implementation.createHTMLDocument();
+      container = separateWindowDocument.createElement("div");
+      separateWindowDocument.body.appendChild(container);
+      jest.spyOn(separateWindowDocument.body,"addEventListener");
+      jest.spyOn(document.body,"addEventListener");
+      expectedWarnings = [];
+      root = createRoot(container);
+    });
+
+    it("should add the pointerup event to the separate document NOT the main document", () => {
+      const { leftElement } = setupMockedGroup();
+
+      act(() => {
+        dispatchPointerEvent("pointerdown", leftElement);
+        dispatchPointerEvent("pointerup", leftElement);
+      });
+
+      expect(separateWindowDocument.body.addEventListener).toHaveBeenCalledWith("pointerup", expect.anything(), expect.anything());
+      expect(document.body.addEventListener).not.toHaveBeenCalled();
+
+    });
+  });
+
+
   describe("data attributes", () => {
     test("should initialize with the correct props based attributes", () => {
       const { leftElement, rightElement } = setupMockedGroup();

--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -327,9 +327,11 @@ function updateListeners() {
         }
       });
     }
-
-    window.addEventListener("pointerup", handlePointerUp, options);
-    window.addEventListener("pointercancel", handlePointerUp, options);
+    ownerDocumentCounts.forEach((count, ownerDocument) => {
+      const { body } = ownerDocument;
+      body.addEventListener("pointerup", handlePointerUp, options);
+      body.addEventListener("pointercancel", handlePointerUp, options);
+    });
   } else {
     ownerDocumentCounts.forEach((count, ownerDocument) => {
       const { body } = ownerDocument;

--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -327,8 +327,10 @@ function updateListeners() {
         }
       });
     }
-    ownerDocumentCounts.forEach((count, ownerDocument) => {
+
+    ownerDocumentCounts.forEach((_, ownerDocument) => {
       const { body } = ownerDocument;
+
       body.addEventListener("pointerup", handlePointerUp, options);
       body.addEventListener("pointercancel", handlePointerUp, options);
     });


### PR DESCRIPTION
This PR changes which element the handlePointerUp event handler is added to, it now adds the event handler to the body element of each owner docment where a panelResizeHandle is rendered. This accounts for use cases where the panelResizeHandle is rendered in a document that is in a child window.

This PR also adds a test for checking which document body the event handler is added to, which demonstrates a usecase where PanelResizeHandles are rendered to a separate document.

addresses #468 