### PR TITLE
Fix compatibility with cloudflare workers

### DIFF
--- a/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
+++ b/packages/react-resizable-panels/src/PanelResizeHandleRegistry.ts
@@ -300,10 +300,10 @@ function updateCursor() {
   }
 }
 
-let listenersAbortController = new AbortController();
+let listenersAbortController: AbortController | undefined;
 
 function updateListeners() {
-  listenersAbortController.abort();
+  listenersAbortController?.abort();
   listenersAbortController = new AbortController();
 
   const options: AddEventListenerOptions = {


### PR DESCRIPTION
cloudflare workers throw error if you initialize AbortController in global scope see: https://github.com/cloudflare/workerd/issues/3657, https://github.com/bvaughn/react-resizable-panels/issues/483