### PR TITLE
feat: add a customizing step for panel group

### DIFF
--- a/packages/react-resizable-panels-website/index.tsx
+++ b/packages/react-resizable-panels-website/index.tsx
@@ -15,6 +15,7 @@ import CollapsibleExampleRoute from "./src/routes/examples/Collapsible";
 import VerticalExampleRoute from "./src/routes/examples/Vertical";
 import EndToEndTestingRoute from "./src/routes/EndToEndTesting";
 import IframeRoute from "./src/routes/iframe";
+import CustomStepRoute from "./src/routes/examples/CustomStep";
 
 const router = createBrowserRouter([
   {
@@ -61,7 +62,10 @@ const router = createBrowserRouter([
     path: "/examples/vertical",
     element: <VerticalExampleRoute />,
   },
-
+  {
+    path: "/examples/custom-step",
+    element: <CustomStepRoute />,
+  },
   // Special route used by e2e tests
   {
     path: "/__e2e",

--- a/packages/react-resizable-panels-website/src/routes/Home/index.tsx
+++ b/packages/react-resizable-panels-website/src/routes/Home/index.tsx
@@ -16,6 +16,7 @@ const LINKS = [
   { path: "external-persistence", title: "External persistence" },
   { path: "imperative-panel-api", title: "Imperative Panel API" },
   { path: "imperative-panel-group-api", title: "Imperative PanelGroup API" },
+  { path: "custom-step", title: "Layout with custom step" },
 ];
 
 export default function HomeRoute() {

--- a/packages/react-resizable-panels-website/src/routes/examples/CustomStep.module.css
+++ b/packages/react-resizable-panels-website/src/routes/examples/CustomStep.module.css
@@ -1,0 +1,29 @@
+
+
+.ChangeStepRow {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.ChangeStepForm {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1ch;
+  margin: 0;
+}
+
+.StepInput {
+  width: 7ch;
+  padding: 0 0 0 1ch;
+  background-color: var(--color-input-background);
+  border: 2px solid var(--color-input-border);
+  color: var(--color-input);
+  border-radius: 0.5rem;
+  outline: none;
+}
+.StepInput:focus {
+  outline: none;
+  border-color: var(--color-input-border-focused);
+}

--- a/packages/react-resizable-panels-website/src/routes/examples/CustomStep.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/CustomStep.tsx
@@ -1,0 +1,90 @@
+import { Panel, PanelGroup } from "react-resizable-panels";
+
+import { ResizeHandle } from "../../components/ResizeHandle";
+
+import Example from "./Example";
+import sharedStyles from "./shared.module.css";
+import styles from "./CustomStep.module.css";
+
+import { ChangeEvent, useState } from "react";
+
+export default function CustomStepRoute() {
+  return (
+    <Example
+      code={CODE}
+      exampleNode={<Content />}
+      headerNode={
+        <>
+          <p>
+            This example is a 3-column horizontal <code>PanelGroup</code> with
+            custom step size. You can change a step size by number input
+          </p>
+          <p>
+            These panels use the <code>step</code> property to change the
+            resizing behavior.
+          </p>
+        </>
+      }
+      title="Horizontal layouts with custom step size"
+    />
+  );
+}
+
+function Content() {
+  const [step, setStep] = useState<number>(10);
+
+  const onStepInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.value;
+    console.log("size-input-left", value);
+    setStep(parseFloat(value));
+  };
+
+  return (
+    <>
+      <div className={styles.ChangeStepRow}>
+        <div className={styles.ChangeStepForm}>
+          Custom Step
+          <input
+            className={styles.StepInput}
+            id="stepInput"
+            onChange={onStepInputChange}
+            placeholder="Step (1 to 100)"
+            type="text"
+            value={step}
+          />
+        </div>
+      </div>
+      <div className={sharedStyles.PanelGroupWrapper}>
+        <PanelGroup
+          className={sharedStyles.PanelGroup}
+          direction="horizontal"
+          step={step}
+        >
+          <Panel
+            className={sharedStyles.PanelRow}
+            defaultSize={30}
+            minSize={10}
+          >
+            <div className={sharedStyles.Centered}>left</div>
+          </Panel>
+          <ResizeHandle className={sharedStyles.ResizeHandle} />
+          <Panel className={sharedStyles.PanelRow} defaultSize={10} minSize={5}>
+            <div className={sharedStyles.Centered}>right</div>
+          </Panel>
+        </PanelGroup>
+      </div>
+    </>
+  );
+}
+
+const CODE = `
+  <PanelGroup direction="horizontal" step={step}>
+    <Panel defaultSize={30} minSize={10}>
+      <div>left</div>
+    </Panel>
+    <ResizeHandle />
+    <Panel defaultSize={10} minSize={5}>
+      <div >right</div>
+    </Panel>
+  </PanelGroup>
+`;

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -99,7 +99,7 @@ export type PanelGroupProps = Omit<
     storage?: PanelGroupStorage;
     style?: CSSProperties;
     tagName?: keyof HTMLElementTagNameMap;
-
+    step?: number;
     // Better TypeScript hinting
     dir?: "auto" | "ltr" | "rtl" | undefined;
   }>;
@@ -120,6 +120,7 @@ function PanelGroupWithForwardedRef({
   storage = defaultStorage,
   style: styleFromProps,
   tagName: Type = "div",
+  step,
   ...rest
 }: PanelGroupProps & {
   forwardedRef: ForwardedRef<ImperativePanelGroupHandle>;
@@ -142,6 +143,7 @@ function PanelGroupWithForwardedRef({
     keyboardResizeBy: number | null;
     onLayout: PanelGroupOnLayout | null;
     storage: PanelGroupStorage;
+    step?: number;
   }>({
     autoSaveId,
     direction,
@@ -150,6 +152,7 @@ function PanelGroupWithForwardedRef({
     keyboardResizeBy,
     onLayout,
     storage,
+    step,
   });
 
   const eagerValuesRef = useRef<{
@@ -182,7 +185,7 @@ function PanelGroupWithForwardedRef({
         return layout;
       },
       setLayout: (unsafeLayout: number[]) => {
-        const { onLayout } = committedValuesRef.current;
+        const { onLayout, step } = committedValuesRef.current;
         const { layout: prevLayout, panelDataArray } = eagerValuesRef.current;
 
         const safeLayout = validatePanelGroupLayout({
@@ -190,6 +193,7 @@ function PanelGroupWithForwardedRef({
           panelConstraints: panelDataArray.map(
             (panelData) => panelData.constraints
           ),
+          step,
         });
 
         if (!areEqual(prevLayout, safeLayout)) {
@@ -219,6 +223,7 @@ function PanelGroupWithForwardedRef({
     committedValuesRef.current.id = groupId;
     committedValuesRef.current.onLayout = onLayout;
     committedValuesRef.current.storage = storage;
+    committedValuesRef.current.step = step;
   });
 
   useWindowSplitterPanelGroupBehavior({
@@ -559,7 +564,8 @@ function PanelGroupWithForwardedRef({
     if (eagerValuesRef.current.panelDataArrayChanged) {
       eagerValuesRef.current.panelDataArrayChanged = false;
 
-      const { autoSaveId, onLayout, storage } = committedValuesRef.current;
+      const { autoSaveId, onLayout, storage, step } =
+        committedValuesRef.current;
       const { layout: prevLayout, panelDataArray } = eagerValuesRef.current;
 
       // If this panel has been configured to persist sizing information,
@@ -588,8 +594,8 @@ function PanelGroupWithForwardedRef({
         panelConstraints: panelDataArray.map(
           (panelData) => panelData.constraints
         ),
+        step,
       });
-
       if (!areEqual(prevLayout, nextLayout)) {
         setLayout(nextLayout);
 
@@ -641,6 +647,7 @@ function PanelGroupWithForwardedRef({
         id: groupId,
         keyboardResizeBy,
         onLayout,
+        step,
       } = committedValuesRef.current;
       const { layout: prevLayout, panelDataArray } = eagerValuesRef.current;
 
@@ -678,6 +685,7 @@ function PanelGroupWithForwardedRef({
         pivotIndices,
         prevLayout,
         trigger: isKeyDown(event) ? "keyboard" : "mouse-or-touch",
+        step,
       });
 
       const layoutChanged = !compareLayouts(prevLayout, nextLayout);
@@ -732,7 +740,7 @@ function PanelGroupWithForwardedRef({
   // External APIs are safe to memoize via committed values ref
   const resizePanel = useCallback(
     (panelData: PanelData, unsafePanelSize: number) => {
-      const { onLayout } = committedValuesRef.current;
+      const { onLayout, step } = committedValuesRef.current;
 
       const { layout: prevLayout, panelDataArray } = eagerValuesRef.current;
 
@@ -765,6 +773,7 @@ function PanelGroupWithForwardedRef({
         pivotIndices,
         prevLayout,
         trigger: "imperative-api",
+        step,
       });
 
       if (!compareLayouts(prevLayout, nextLayout)) {

--- a/packages/react-resizable-panels/src/utils/adjustLayoutByDelta.ts
+++ b/packages/react-resizable-panels/src/utils/adjustLayoutByDelta.ts
@@ -3,6 +3,7 @@ import { assert } from "./assert";
 import { fuzzyCompareNumbers } from "./numbers/fuzzyCompareNumbers";
 import { fuzzyLayoutsEqual } from "./numbers/fuzzyLayoutsEqual";
 import { fuzzyNumbersEqual } from "./numbers/fuzzyNumbersEqual";
+import { roundByStep, roundToMultiple } from "./numbers/roundByStep";
 import { resizePanel } from "./resizePanel";
 
 // All units must be in percentages; pixel values should be pre-converted
@@ -13,6 +14,7 @@ export function adjustLayoutByDelta({
   pivotIndices,
   prevLayout,
   trigger,
+  step,
 }: {
   delta: number;
   initialLayout: number[];
@@ -20,6 +22,7 @@ export function adjustLayoutByDelta({
   pivotIndices: number[];
   prevLayout: number[];
   trigger: "imperative-api" | "keyboard" | "mouse-or-touch";
+  step?: number;
 }): number[] {
   if (fuzzyNumbersEqual(delta, 0)) {
     return initialLayout;
@@ -187,10 +190,15 @@ export function adjustLayoutByDelta({
       );
 
       const unsafeSize = prevSize - deltaRemaining;
+
+      const roundedSize = step
+        ? roundByStep({number:unsafeSize, step})
+        : unsafeSize;
+
       const safeSize = resizePanel({
         panelConstraints: panelConstraintsArray,
         panelIndex: index,
-        size: unsafeSize,
+        size: roundedSize,
       });
 
       if (!fuzzyNumbersEqual(prevSize, safeSize)) {
@@ -263,10 +271,15 @@ export function adjustLayoutByDelta({
         );
 
         const unsafeSize = prevSize + deltaRemaining;
+
+        const roundedSize = step
+          ? roundByStep({number:unsafeSize, step})
+          : unsafeSize;
+
         const safeSize = resizePanel({
           panelConstraints: panelConstraintsArray,
           panelIndex: index,
-          size: unsafeSize,
+          size: roundedSize,
         });
 
         if (!fuzzyNumbersEqual(prevSize, safeSize)) {

--- a/packages/react-resizable-panels/src/utils/numbers/roundByStep.ts
+++ b/packages/react-resizable-panels/src/utils/numbers/roundByStep.ts
@@ -1,0 +1,5 @@
+export const roundByStep=({number,step,minSize=1,maxSize=100}:{number:number,step:number,minSize?:number,maxSize?:number})=>{
+  
+    const preparedStep=Math.max(Math.min(step,maxSize),minSize)
+    return Math.round(number/preparedStep)*step
+}

--- a/packages/react-resizable-panels/src/utils/validatePanelGroupLayout.ts
+++ b/packages/react-resizable-panels/src/utils/validatePanelGroupLayout.ts
@@ -2,15 +2,18 @@ import { isDevelopment } from "#is-development";
 import { PanelConstraints } from "../Panel";
 import { assert } from "./assert";
 import { fuzzyNumbersEqual } from "./numbers/fuzzyNumbersEqual";
+import { roundByStep } from "./numbers/roundByStep";
 import { resizePanel } from "./resizePanel";
 
 // All units must be in percentages; pixel values should be pre-converted
 export function validatePanelGroupLayout({
   layout: prevLayout,
   panelConstraints,
+  step,
 }: {
   layout: number[];
   panelConstraints: PanelConstraints[];
+  step?:number
 }): number[] {
   const nextLayout = [...prevLayout];
   const nextLayoutTotalSize = nextLayout.reduce(
@@ -52,12 +55,15 @@ export function validatePanelGroupLayout({
   for (let index = 0; index < panelConstraints.length; index++) {
     const unsafeSize = nextLayout[index];
     assert(unsafeSize != null, `No layout data found for index ${index}`);
+    
+    const roundedSize=step?roundByStep({number:unsafeSize, step}):unsafeSize;
 
     const safeSize = resizePanel({
       panelConstraints,
       panelIndex: index,
-      size: unsafeSize,
+      size: roundedSize,
     });
+
 
     if (unsafeSize != safeSize) {
       remainingSize += unsafeSize - safeSize;


### PR DESCRIPTION
Add a new property to the `PannelGroup`: step.
This property allows you to round the panel size to a custom value. 
Create a new example page to demonstrate this functionality.