### PR TITLE
Add precision prop docs

### DIFF
--- a/packages/react-resizable-panels-website/src/routes/examples/Vertical.tsx
+++ b/packages/react-resizable-panels-website/src/routes/examples/Vertical.tsx
@@ -35,9 +35,10 @@ function Content() {
       <PanelGroup className={styles.PanelGroup} direction="vertical">
         <Panel
           className={styles.PanelColumn}
-          defaultSize={50}
+          defaultSize={50.25}
           maxSize={75}
           minSize={10}
+          precision={2}
         >
           <div className={styles.Centered}>top</div>
         </Panel>

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -52,22 +52,23 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 ### `Panel`
 
-| prop            | type                      | description                                                                                   |
-| :-------------- | :------------------------ | :-------------------------------------------------------------------------------------------- |
-| `children`      | `ReactNode`               | Arbitrary React element(s)                                                                    |
-| `className`     | `?string`                 | Class name to attach to root element                                                          |
-| `collapsedSize` | `?number=0`               | Panel should collapse to this size                                                            |
-| `collapsible`   | `?boolean=false`          | Panel should collapse when resized beyond its `minSize`                                       |
-| `defaultSize`   | `?number`                 | Initial size of panel (numeric value between 1-100)                                           |
-| `id`            | `?string`                 | Panel id (unique within group); falls back to `useId` when not provided                       |
-| `maxSize`       | `?number = 100`           | Maximum allowable size of panel (numeric value between 1-100); defaults to `100`              |
-| `minSize`       | `?number = 10`            | Minimum allowable size of panel (numeric value between 1-100); defaults to `10`               |
-| `onCollapse`    | `?() => void`             | Called when panel is collapsed                                                                |
-| `onExpand`      | `?() => void`             | Called when panel is expanded                                                                 |
-| `onResize`      | `?(size: number) => void` | Called when panel is resized; `size` parameter is a numeric value between 1-100. <sup>1</sup> |
-| `order`         | `?number`                 | Order of panel within group; required for groups with conditionally rendered panels           |
-| `style`         | `?CSSProperties`          | CSS style to attach to root element                                                           |
-| `tagName`       | `?string = "div"`         | HTML element tag name for root element                                                        |
+| prop             | type                      | description                                                                                     |
+|:-----------------|:--------------------------|:------------------------------------------------------------------------------------------------|
+| `children`       | `ReactNode`               | Arbitrary React element(s)                                                                      |
+| `className`      | `?string`                 | Class name to attach to root element                                                            |
+| `collapsedSize`  | `?number=0`               | Panel should collapse to this size                                                              |
+| `collapsible`    | `?boolean=false`          | Panel should collapse when resized beyond its `minSize`                                         |
+| `defaultSize`    | `?number`                 | Initial size of panel (numeric value between 1-100)                                             |
+| `id`             | `?string`                 | Panel id (unique within group); falls back to `useId` when not provided                         |
+| `maxSize`        | `?number = 100`           | Maximum allowable size of panel (numeric value between 1-100); defaults to `100`                |
+| `minSize`        | `?number = 10`            | Minimum allowable size of panel (numeric value between 1-100); defaults to `10`                 |
+| `precision`      | `?number = 1`             | Decimal precision of `data-panel-size`. defaults to `1`                                         |
+| `onCollapse`     | `?() => void`             | Called when panel is collapsed                                                                  |
+| `onExpand`       | `?() => void`             | Called when panel is expanded                                                                   |
+| `onResize`       | `?(size: number) => void` | Called when panel is resized; `size` parameter is a numeric value between 1-100. <sup>1</sup>   |
+| `order`          | `?number`                 | Order of panel within group; required for groups with conditionally rendered panels             |
+| `style`          | `?CSSProperties`          | CSS style to attach to root element                                                             |
+| `tagName`        | `?string = "div"`         | HTML element tag name for root element                                                          |
 
 <sup>1</sup>: If any `Panel` has an `onResize` callback, the `order` prop should be provided for all `Panel`s.
 

--- a/packages/react-resizable-panels/README.md
+++ b/packages/react-resizable-panels/README.md
@@ -52,23 +52,23 @@ import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 
 ### `Panel`
 
-| prop             | type                      | description                                                                                     |
-|:-----------------|:--------------------------|:------------------------------------------------------------------------------------------------|
-| `children`       | `ReactNode`               | Arbitrary React element(s)                                                                      |
-| `className`      | `?string`                 | Class name to attach to root element                                                            |
-| `collapsedSize`  | `?number=0`               | Panel should collapse to this size                                                              |
-| `collapsible`    | `?boolean=false`          | Panel should collapse when resized beyond its `minSize`                                         |
-| `defaultSize`    | `?number`                 | Initial size of panel (numeric value between 1-100)                                             |
-| `id`             | `?string`                 | Panel id (unique within group); falls back to `useId` when not provided                         |
-| `maxSize`        | `?number = 100`           | Maximum allowable size of panel (numeric value between 1-100); defaults to `100`                |
-| `minSize`        | `?number = 10`            | Minimum allowable size of panel (numeric value between 1-100); defaults to `10`                 |
+| prop            | type                      | description                                                                                   |
+| :-------------- | :------------------------ | :-------------------------------------------------------------------------------------------- |
+| `children`      | `ReactNode`               | Arbitrary React element(s)                                                                    |
+| `className`     | `?string`                 | Class name to attach to root element                                                          |
+| `collapsedSize` | `?number=0`               | Panel should collapse to this size                                                            |
+| `collapsible`   | `?boolean=false`          | Panel should collapse when resized beyond its `minSize`                                       |
+| `defaultSize`   | `?number`                 | Initial size of panel (numeric value between 1-100)                                           |
+| `id`            | `?string`                 | Panel id (unique within group); falls back to `useId` when not provided                       |
+| `maxSize`       | `?number = 100`           | Maximum allowable size of panel (numeric value between 1-100); defaults to `100`              |
+| `minSize`       | `?number = 10`            | Minimum allowable size of panel (numeric value between 1-100); defaults to `10`               |
+| `onCollapse`    | `?() => void`             | Called when panel is collapsed                                                                |
+| `onExpand`      | `?() => void`             | Called when panel is expanded                                                                 |
+| `onResize`      | `?(size: number) => void` | Called when panel is resized; `size` parameter is a numeric value between 1-100. <sup>1</sup> |
+| `order`         | `?number`                 | Order of panel within group; required for groups with conditionally rendered panels           |
+| `style`         | `?CSSProperties`          | CSS style to attach to root element                                                           |
+| `tagName`       | `?string = "div"`         | HTML element tag name for root element                                                        |
 | `precision`      | `?number = 1`             | Decimal precision of `data-panel-size`. defaults to `1`                                         |
-| `onCollapse`     | `?() => void`             | Called when panel is collapsed                                                                  |
-| `onExpand`       | `?() => void`             | Called when panel is expanded                                                                   |
-| `onResize`       | `?(size: number) => void` | Called when panel is resized; `size` parameter is a numeric value between 1-100. <sup>1</sup>   |
-| `order`          | `?number`                 | Order of panel within group; required for groups with conditionally rendered panels             |
-| `style`          | `?CSSProperties`          | CSS style to attach to root element                                                             |
-| `tagName`        | `?string = "div"`         | HTML element tag name for root element                                                          |
 
 <sup>1</sup>: If any `Panel` has an `onResize` callback, the `order` prop should be provided for all `Panel`s.
 

--- a/packages/react-resizable-panels/src/Panel.ts
+++ b/packages/react-resizable-panels/src/Panel.ts
@@ -66,6 +66,7 @@ export type PanelProps<
     id?: string;
     maxSize?: number | undefined;
     minSize?: number | undefined;
+    precision?: number;
     onCollapse?: PanelOnCollapse;
     onExpand?: PanelOnExpand;
     onResize?: PanelOnResize;
@@ -84,6 +85,7 @@ export function PanelWithForwardedRef({
   id: idFromProps,
   maxSize,
   minSize,
+  precision = 1,
   onCollapse,
   onExpand,
   onResize,
@@ -229,7 +231,7 @@ export function PanelWithForwardedRef({
     ]
   );
 
-  const style = getPanelStyle(panelDataRef.current, defaultSize);
+  const style = getPanelStyle(panelDataRef.current, defaultSize, precision);
 
   return createElement(Type, {
     ...rest,
@@ -247,7 +249,7 @@ export function PanelWithForwardedRef({
     [DATA_ATTRIBUTES.panel]: "",
     [DATA_ATTRIBUTES.panelCollapsible]: collapsible || undefined,
     [DATA_ATTRIBUTES.panelId]: panelId,
-    [DATA_ATTRIBUTES.panelSize]: parseFloat("" + style.flexGrow).toFixed(1),
+    [DATA_ATTRIBUTES.panelSize]: parseFloat("" + style.flexGrow).toFixed(precision),
   });
 }
 

--- a/packages/react-resizable-panels/src/PanelGroup.ts
+++ b/packages/react-resizable-panels/src/PanelGroup.ts
@@ -475,7 +475,7 @@ function PanelGroupWithForwardedRef({
 
   // This API should never read from committedValuesRef
   const getPanelStyle = useCallback(
-    (panelData: PanelData, defaultSize: number | undefined) => {
+    (panelData: PanelData, defaultSize: number | undefined, precision = 1) => {
       const { panelDataArray } = eagerValuesRef.current;
 
       const panelIndex = findPanelDataIndex(panelDataArray, panelData);
@@ -486,6 +486,7 @@ function PanelGroupWithForwardedRef({
         layout,
         panelData: panelDataArray,
         panelIndex,
+        precision: precision + 2
       });
     },
     [dragState, layout]

--- a/packages/react-resizable-panels/src/PanelGroupContext.ts
+++ b/packages/react-resizable-panels/src/PanelGroupContext.ts
@@ -20,7 +20,8 @@ export type TPanelGroupContext = {
   getPanelSize: (panelData: PanelData) => number;
   getPanelStyle: (
     panelData: PanelData,
-    defaultSize: number | undefined
+    defaultSize: number | undefined,
+    precision: number
   ) => CSSProperties;
   groupId: string;
   isPanelCollapsed: (panelData: PanelData) => boolean;


### PR DESCRIPTION
I understand that pixel-based panel sizing isn't officially supported due to the added complexity. However, in my use case, I needed more precise control over panel sizes to better approximate specific pixel values.

To address this, I’ve added a precision prop to the component. This prop allows me to control the decimal precision of the `data-panel-size` (e.g., 2 means two decimal places), which helps approximate pixel values more closely within the percentage-based sizing system.

While it’s not perfect pixel control, it gives me a good enough level of precision for layout consistency across different screen sizes.
