### PR TITLE
Read `Panel` pixel size using `offsetWidth`/`offsetHeight` rather than `inlineSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Replace `"unset"` styles with safer override values
 - Use capture phase for `"pointerdown"` and `"pointerup"` events; this is necessary for compatibility with certain UI libraries like Blueprint JS
+- Read `Panel` pixel size using `offsetWidth`/`offsetHeight` rather than `inlineSize` to avoid an edgecase bug with `ResizeObserver`
 
 ## 4.3.0
 

--- a/lib/global/utils/notifyPanelOnResize.ts
+++ b/lib/global/utils/notifyPanelOnResize.ts
@@ -19,12 +19,15 @@ export function notifyPanelOnResize(
 
   const groupSize = calculateAvailableGroupSize({ group });
 
+  const panelSize =
+    group.orientation === "horizontal"
+      ? panel.element.offsetWidth
+      : panel.element.offsetHeight;
+
   const prevSize = panel.mutableValues.prevSize;
   const nextSize = {
-    asPercentage: formatLayoutNumber(
-      (resizeObserverSize.inlineSize / groupSize) * 100
-    ),
-    inPixels: resizeObserverSize.inlineSize
+    asPercentage: formatLayoutNumber((panelSize / groupSize) * 100),
+    inPixels: panelSize
   };
   panel.mutableValues.prevSize = nextSize;
 


### PR DESCRIPTION
to work around an edge case bug with `ResizeObserver`

Resolves #586