### PR TITLE
fix #608: bidirectional cursor flashes while dragging

### DIFF
--- a/lib/global/event-handlers/onDocumentPointerLeave.ts
+++ b/lib/global/event-handlers/onDocumentPointerLeave.ts
@@ -7,7 +7,6 @@ export function onDocumentPointerLeave(event: PointerEvent) {
   switch (interactionState.state) {
     case "active": {
       updateActiveHitRegions({
-        document: event.currentTarget as Document,
         event,
         hitRegions: interactionState.hitRegions,
         initialLayoutMap: interactionState.initialLayoutMap,

--- a/lib/global/event-handlers/onDocumentPointerMove.ts
+++ b/lib/global/event-handlers/onDocumentPointerMove.ts
@@ -37,7 +37,6 @@ export function onDocumentPointerMove(event: PointerEvent) {
       }
 
       updateActiveHitRegions({
-        document: event.currentTarget as Document,
         event,
         hitRegions: interactionState.hitRegions,
         initialLayoutMap: interactionState.initialLayoutMap,

--- a/lib/global/utils/updateActiveHitRegion.ts
+++ b/lib/global/utils/updateActiveHitRegion.ts
@@ -6,21 +6,18 @@ import {
   CURSOR_FLAG_VERTICAL_MIN
 } from "../../constants";
 import type { Point } from "../../types";
-import { updateCursorStyle } from "../cursor/updateCursorStyle";
 import type { HitRegion } from "../dom/calculateHitRegions";
 import { update, type MountedGroupMap } from "../mutableState";
 import { adjustLayoutByDelta } from "./adjustLayoutByDelta";
 import { layoutsEqual } from "./layoutsEqual";
 
 export function updateActiveHitRegions({
-  document,
   event,
   hitRegions,
   initialLayoutMap,
   mountedGroups,
   pointerDownAtPoint
 }: {
-  document: Document;
   event: {
     clientX: number;
     clientY: number;
@@ -119,6 +116,4 @@ export function updateActiveHitRegions({
     cursorFlags,
     mountedGroups: nextMountedGroups
   });
-
-  updateCursorStyle(document);
 }


### PR DESCRIPTION
Fixes #608.

It may not be correct to remove this call, but it doesn't seem to do anything except make the cursor jittery.

Before:

![before](https://github.com/user-attachments/assets/25739260-38f7-4afe-8556-c02ceea43f97)

After

![after](https://github.com/user-attachments/assets/e9304979-3704-4083-b4bf-aa317531a18a)

(Ignore colours flashing a bit on the 2nd one - it's just an artifact of the gif)

