### PR TITLE
Add data attribute to disable hover & drag on elements near separator (#630)

### DIFF
--- a/lib/global/utils/isViableHitTarget.ts
+++ b/lib/global/utils/isViableHitTarget.ts
@@ -20,8 +20,15 @@ export function isViableHitTarget({
   hitRegion: DOMRect;
   pointerEventTarget: EventTarget | null;
 }) {
+  if (!isHTMLElement(pointerEventTarget)) {
+    return true;
+  }
+
+  if (pointerEventTarget.closest("[data-resize-disabled]")) {
+    return false;
+  }
+
   if (
-    !isHTMLElement(pointerEventTarget) ||
     pointerEventTarget.contains(groupElement) ||
     groupElement.contains(pointerEventTarget)
   ) {


### PR DESCRIPTION
Added a check that ignores elements with the data attribute `data-resize-disabled`. This is for disabling resizing when interacting with something like a button near or over a separator.

I tried making the least disruptive change I could think of, but maybe this prop should actually be exposed by the library with a hook or something. Might not be needed though if it's more of an edge case.

Fixes #630 