### PR TITLE
Disable recent min-threshold change

### DIFF
--- a/lib/global/utils/adjustLayoutByDelta.test.ts
+++ b/lib/global/utils/adjustLayoutByDelta.test.ts
@@ -1999,24 +1999,25 @@ describe("adjustLayoutByDelta", () => {
               expectedLayout: closed
             }
           ],
-          [
-            "open if delta is greater than minimum threshold",
-            {
-              initialLayout: closed,
-              prevLayout: closed,
-              delta: panelId === "left" ? 6 : -6,
-              expectedLayout: open
-            }
-          ],
-          [
-            "close if delta is less than minimum threshold",
-            {
-              initialLayout: closed,
-              prevLayout: open,
-              delta: panelId === "left" ? 4 : -4,
-              expectedLayout: closed
-            }
-          ],
+          // TODO Re-enable if/when this behavior change is re-enabled
+          // [
+          //   "open if delta is greater than minimum threshold",
+          //   {
+          //     initialLayout: closed,
+          //     prevLayout: closed,
+          //     delta: panelId === "left" ? 6 : -6,
+          //     expectedLayout: open
+          //   }
+          // ],
+          // [
+          //   "close if delta is less than minimum threshold",
+          //   {
+          //     initialLayout: closed,
+          //     prevLayout: open,
+          //     delta: panelId === "left" ? 4 : -4,
+          //     expectedLayout: closed
+          //   }
+          // ],
           [
             "remain open if delta is more than minimum threshold",
             {
@@ -2101,24 +2102,25 @@ describe("adjustLayoutByDelta", () => {
               expectedLayout: closed
             }
           ],
-          [
-            "open if delta is greater than minimum threshold",
-            {
-              initialLayout: closed,
-              prevLayout: closed,
-              delta: panelId === "left" ? 6 : -6,
-              expectedLayout: open
-            }
-          ],
-          [
-            "close if delta is less than minimum threshold",
-            {
-              initialLayout: closed,
-              prevLayout: open,
-              delta: panelId === "left" ? 4 : -4,
-              expectedLayout: closed
-            }
-          ],
+          // TODO Re-enable if/when this behavior change is re-enabled
+          // [
+          //   "open if delta is greater than minimum threshold",
+          //   {
+          //     initialLayout: closed,
+          //     prevLayout: closed,
+          //     delta: panelId === "left" ? 6 : -6,
+          //     expectedLayout: open
+          //   }
+          // ],
+          // [
+          //   "close if delta is less than minimum threshold",
+          //   {
+          //     initialLayout: closed,
+          //     prevLayout: open,
+          //     delta: panelId === "left" ? 4 : -4,
+          //     expectedLayout: closed
+          //   }
+          // ],
           [
             "remain open if delta is more than minimum threshold",
             {

--- a/lib/global/utils/adjustLayoutByDelta.ts
+++ b/lib/global/utils/adjustLayoutByDelta.ts
@@ -131,67 +131,69 @@ export function adjustLayoutByDelta({
         }
         break;
       }
-      default: {
-        // If we're starting from a collapsed state, dragging past the halfway point should cause the panel to expand
-        // This can happen for positive or negative drags, and panels on either side of the separator can be collapsible
-        // The easiest way to support this is to detect this scenario and pre-adjust the delta before applying the rest of the layout algorithm
-        // DEBUG.push(`edge case check 3: collapsible panels`);
+      // TODO Re-enable this once the Firefox behavior has been corrected
+      //      See github.com/bvaughn/react-resizable-panels/discussions/643
+      // default: {
+      //   // If we're starting from a collapsed state, dragging past the halfway point should cause the panel to expand
+      //   // This can happen for positive or negative drags, and panels on either side of the separator can be collapsible
+      //   // The easiest way to support this is to detect this scenario and pre-adjust the delta before applying the rest of the layout algorithm
+      //   // DEBUG.push(`edge case check 3: collapsible panels`);
 
-        const index = delta < 0 ? secondPivotIndex : firstPivotIndex;
-        const panelConstraints = panelConstraintsArray[index];
-        assert(
-          panelConstraints,
-          `Panel constraints not found for index ${index}`
-        );
+      //   const index = delta < 0 ? secondPivotIndex : firstPivotIndex;
+      //   const panelConstraints = panelConstraintsArray[index];
+      //   assert(
+      //     panelConstraints,
+      //     `Panel constraints not found for index ${index}`
+      //   );
 
-        const { collapsible, collapsedSize, minSize } = panelConstraints;
-        if (collapsible) {
-          const isSecondPanel = index === secondPivotIndex;
+      //   const { collapsible, collapsedSize, minSize } = panelConstraints;
+      //   if (collapsible) {
+      //     const isSecondPanel = index === secondPivotIndex;
 
-          // DEBUG.push(`  -> collapsible ${isSecondPanel ? "2nd" : "1st"} panel`);
-          if (delta > 0) {
-            const gapSize = minSize - collapsedSize;
-            const halfwayPoint = gapSize / 2;
-            // DEBUG.push(`  -> halfway point: ${halfwayPoint}`);
-            // DEBUG.push(`    -> between collapsed: ${collapsedSize}`);
-            // DEBUG.push(`    -> and min: ${minSize}`);
+      //     // DEBUG.push(`  -> collapsible ${isSecondPanel ? "2nd" : "1st"} panel`);
+      //     if (delta > 0) {
+      //       const gapSize = minSize - collapsedSize;
+      //       const halfwayPoint = gapSize / 2;
+      //       // DEBUG.push(`  -> halfway point: ${halfwayPoint}`);
+      //       // DEBUG.push(`    -> between collapsed: ${collapsedSize}`);
+      //       // DEBUG.push(`    -> and min: ${minSize}`);
 
-            if (compareLayoutNumbers(delta, minSize) < 0) {
-              // DEBUG.push(`  -> adjusting delta from: ${delta}`);
-              delta =
-                compareLayoutNumbers(delta, halfwayPoint) <= 0 ? 0 : gapSize;
-              // DEBUG.push(`  -> adjusting delta to: ${delta}`);
-            }
-          } else {
-            const gapSize = minSize - collapsedSize;
-            const halfwayPoint = 100 - gapSize / 2;
-            // DEBUG.push(`  -> halfway point: ${halfwayPoint}`);
-            // DEBUG.push(`    -> between collapsed: ${100 - collapsedSize}`);
-            // DEBUG.push(`    -> and min: ${100 - minSize}`);
+      //       if (compareLayoutNumbers(delta, minSize) < 0) {
+      //         // DEBUG.push(`  -> adjusting delta from: ${delta}`);
+      //         delta =
+      //           compareLayoutNumbers(delta, halfwayPoint) <= 0 ? 0 : gapSize;
+      //         // DEBUG.push(`  -> adjusting delta to: ${delta}`);
+      //       }
+      //     } else {
+      //       const gapSize = minSize - collapsedSize;
+      //       const halfwayPoint = 100 - gapSize / 2;
+      //       // DEBUG.push(`  -> halfway point: ${halfwayPoint}`);
+      //       // DEBUG.push(`    -> between collapsed: ${100 - collapsedSize}`);
+      //       // DEBUG.push(`    -> and min: ${100 - minSize}`);
 
-            if (isSecondPanel) {
-              if (compareLayoutNumbers(Math.abs(delta), minSize) < 0) {
-                // DEBUG.push(`  -> adjusting delta from: ${delta}`);
-                delta =
-                  compareLayoutNumbers(100 + delta, halfwayPoint) > 0
-                    ? 0
-                    : -gapSize;
-                // DEBUG.push(`  -> adjusting delta to: ${delta}`);
-              }
-            } else {
-              if (compareLayoutNumbers(100 + delta, minSize) < 0) {
-                // DEBUG.push(`  -> adjusting delta from: ${delta}`);
-                delta =
-                  compareLayoutNumbers(100 + delta, halfwayPoint) > 0
-                    ? 0
-                    : -gapSize;
-                // DEBUG.push(`  -> adjusting delta to: ${delta}`);
-              }
-            }
-          }
-        }
-        break;
-      }
+      //       if (isSecondPanel) {
+      //         if (compareLayoutNumbers(Math.abs(delta), minSize) < 0) {
+      //           // DEBUG.push(`  -> adjusting delta from: ${delta}`);
+      //           delta =
+      //             compareLayoutNumbers(100 + delta, halfwayPoint) > 0
+      //               ? 0
+      //               : -gapSize;
+      //           // DEBUG.push(`  -> adjusting delta to: ${delta}`);
+      //         }
+      //       } else {
+      //         if (compareLayoutNumbers(100 + delta, minSize) < 0) {
+      //           // DEBUG.push(`  -> adjusting delta from: ${delta}`);
+      //           delta =
+      //             compareLayoutNumbers(100 + delta, halfwayPoint) > 0
+      //               ? 0
+      //               : -gapSize;
+      //           // DEBUG.push(`  -> adjusting delta to: ${delta}`);
+      //         }
+      //       }
+      //     }
+      //   }
+      //   break;
+      // }
     }
     // DEBUG.push("");
   }


### PR DESCRIPTION
Bug #629 reports an inconsistency in collapsable panel behavior which was fixed in #635. That fix caused a behavioral regression, detailed in #639, which was then fixed in #642. This morning another regression has been reported in #643. For now I'm disabling the change.