### PR TITLE
fix: persist setLayout to inMemoryLayouts cache

### DIFF
--- a/lib/global/utils/getImperativeGroupMethods.test.ts
+++ b/lib/global/utils/getImperativeGroupMethods.test.ts
@@ -137,5 +137,23 @@ describe("getImperativeGroupMethods", () => {
         }
       `);
     });
+
+    test("persists layout to inMemoryLayouts cache", () => {
+      const { api, group } = init([
+        { defaultSize: 200, minSize: 100 },
+        { defaultSize: 800 }
+      ]);
+
+      api.setLayout({
+        "A-1": 30,
+        "A-2": 70
+      });
+
+      const panelIdsKey = "A-1,A-2";
+      expect(group.inMemoryLayouts[panelIdsKey]).toEqual({
+        "A-1": 30,
+        "A-2": 70
+      });
+    });
   });
 });

--- a/lib/global/utils/getImperativeGroupMethods.ts
+++ b/lib/global/utils/getImperativeGroupMethods.ts
@@ -67,6 +67,10 @@ export function getImperativeGroupMethods({
             separatorToPanels
           })
         }));
+
+        // Save the layout to in-memory cache so it persists when panel configuration changes
+        const panelIdsKey = group.panels.map(({ id }) => id).join(",");
+        group.inMemoryLayouts[panelIdsKey] = nextLayout;
       }
 
       return nextLayout;


### PR DESCRIPTION
I have a three panel layout and am attempting to persist the absolute width of some panels when conditionally rendering others, i.e. switching between a 2 and 3 panel layout. I can do this via the `setLayout` imperative API method, roughly something like this:

```ts
const lastLayout = useRef<Layout>(ref.current?.getLayout() ?? {})

// This is passed as the Group component's onLayoutChanged prop.
const handleLayoutChanged = (layout: Layout) => {
    const next = {...layout}
    const prev = lastLayout.current
    const nextLength = Object.keys(next).length
    const prevLength = Object.keys(prev).length

    if (prevLength !== nextLength) {
      // Persist these
      if ('navigation' in next && 'navigation' in prev) {
        next.navigation = prev.navigation
      }
      if ('sidebar' in next && 'sidebar' in prev) {
        next.sidebar = prev.sidebar
      }
      // Apply remaining space to content
      if ('content' in next && 'content' in prev) {
        next.content = 100 - (next.navigation ?? 0) - (next.sidebar ?? 0)
      }
      ref.current?.setLayout(next)
    }

    lastLayout.current = next
    onLayoutChanged(next)
  }
```

However, currently `setLayout` doesn't seem to persist layouts to the `inMemoryLayouts` cache. As a result I am finding that when panels subsequently change (in my case on route change in my application), the layout is I assume read from the stale cache, and the panels snap back to the layout received by `handleLayoutChanged` prior to when I called `setLayout`.

This fix just persists those layouts to the cache, which after testing this locally, seems to work.

Let me know if you'd like more detail or a repro.