### PR TITLE
Improve disabled `Panel` and `Separator` UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.6.1
+
+- [658](https://github.com/bvaughn/react-resizable-panels/pull/658): Imperative `Panel` and `Group` APIs ignored `disabled` status when resizing panels; this is an explicit override of the _disabled_ state and is required to support conditionally disabled groups.
+- [658](https://github.com/bvaughn/react-resizable-panels/pull/658): `Separator` component does not set a `cursor: not-allowed` style if the parent `Group` has cursors disabled.
+
 ## 4.6.0
 
 - [657](https://github.com/bvaughn/react-resizable-panels/pull/657): Allow `Panel` and `Separator` components to be disabled

--- a/integrations/tests/tests/pointer-interactions.spec.tsx
+++ b/integrations/tests/tests/pointer-interactions.spec.tsx
@@ -612,4 +612,50 @@ test.describe("pointer interactions", () => {
     await assertLayoutChangeCounts(mainPage, 1);
     await expect(mainPage.getByText('"left": 50')).toBeVisible();
   });
+
+  test("should allow a disabled panel's border to resize another panel indirectly", async ({
+    page: mainPage
+  }) => {
+    const page = await goToUrl(
+      mainPage,
+      <Group>
+        <Panel id="left" />
+        <Panel disabled id="center" />
+        <Panel id="right" />
+      </Group>
+    );
+
+    await assertLayoutChangeCounts(mainPage, 1);
+    await expect(mainPage.getByText('"left": 33')).toBeVisible();
+    await expect(mainPage.getByText('"center": 33')).toBeVisible();
+    await expect(mainPage.getByText('"right": 33')).toBeVisible();
+
+    await resizeHelper(page, ["left", "center"], 100, 0);
+
+    await assertLayoutChangeCounts(mainPage, 2);
+    await expect(mainPage.getByText('"left": 43')).toBeVisible();
+    await expect(mainPage.getByText('"center": 33')).toBeVisible();
+    await expect(mainPage.getByText('"right": 23')).toBeVisible();
+
+    await resizeHelper(page, ["center", "right"], -200, 0);
+
+    await assertLayoutChangeCounts(mainPage, 3);
+    await expect(mainPage.getByText('"left": 23')).toBeVisible();
+    await expect(mainPage.getByText('"center": 33')).toBeVisible();
+    await expect(mainPage.getByText('"right": 43')).toBeVisible();
+
+    await resizeHelper(page, ["center", "right"], 200, 0);
+
+    await assertLayoutChangeCounts(mainPage, 4);
+    await expect(mainPage.getByText('"left": 43')).toBeVisible();
+    await expect(mainPage.getByText('"center": 33')).toBeVisible();
+    await expect(mainPage.getByText('"right": 23')).toBeVisible();
+
+    await resizeHelper(page, ["center", "right"], -100, 0);
+
+    await assertLayoutChangeCounts(mainPage, 5);
+    await expect(mainPage.getByText('"left": 33')).toBeVisible();
+    await expect(mainPage.getByText('"center": 33')).toBeVisible();
+    await expect(mainPage.getByText('"right": 33')).toBeVisible();
+  });
 });

--- a/lib/components/group/Group.test.tsx
+++ b/lib/components/group/Group.test.tsx
@@ -311,6 +311,7 @@ describe("Group", () => {
       render(<Repro />);
     });
   });
+
   describe("onLayoutChange and onLayoutChanged", () => {
     beforeEach(() => {
       setElementBoundsFunction((element) => {

--- a/lib/components/group/types.ts
+++ b/lib/components/group/types.ts
@@ -48,11 +48,14 @@ export type RegisteredGroup = {
 };
 
 export type GroupContextType = {
+  disableCursor: boolean;
   getPanelStyles: (groupId: string, panelId: string) => CSSProperties;
   id: string;
   orientation: Orientation;
   registerPanel: (panel: RegisteredPanel) => () => void;
   registerSeparator: (separator: RegisteredSeparator) => () => void;
+  togglePanelDisabled: (id: string, disabled: boolean) => void;
+  toggleSeparatorDisabled: (id: string, disabled: boolean) => void;
 };
 
 /**

--- a/lib/components/panel/types.ts
+++ b/lib/components/panel/types.ts
@@ -13,7 +13,7 @@ export type PanelConstraints = {
   collapsedSize: number;
   collapsible: boolean;
   defaultSize: number | undefined;
-  disabled?: boolean | undefined;
+  disabled: boolean | undefined;
   maxSize: number;
   minSize: number;
   panelId: string;

--- a/lib/components/separator/Separator.test.tsx
+++ b/lib/components/separator/Separator.test.tsx
@@ -1,10 +1,116 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { Group } from "../group/Group";
 import { Panel } from "../panel/Panel";
 import { Separator } from "./Separator";
+import { eventEmitter } from "../../global/mutableState";
+import { setElementBoundsFunction } from "../../utils/test/mockBoundingClientRect";
+import { moveSeparator } from "../../global/test/moveSeparator";
 
 describe("Separator", () => {
+  describe("disabled prop", () => {
+    test("changes to disabled prop should not cause the Separator to remount", () => {
+      const onMountedGroupsChange = vi.fn();
+      const removeListener = eventEmitter.addListener(
+        "mountedGroupsChange",
+        onMountedGroupsChange
+      );
+
+      const { rerender } = render(
+        <Group>
+          <Panel />
+          <Separator disabled id="left" />
+          <Panel />
+          <Separator id="right" />
+          <Panel />
+        </Group>
+      );
+      expect(onMountedGroupsChange).toHaveBeenCalled();
+
+      onMountedGroupsChange.mockReset();
+
+      rerender(
+        <Group>
+          <Panel />
+          <Separator id="left" />
+          <Panel />
+          <Separator disabled id="right" />
+          <Panel />
+        </Group>
+      );
+      expect(onMountedGroupsChange).not.toHaveBeenCalled();
+
+      removeListener();
+    });
+
+    test("changes to this prop should update Separator behavior", async () => {
+      setElementBoundsFunction((element) => {
+        switch (element.id) {
+          case "left": {
+            return new DOMRect(0, 0, 50, 50);
+          }
+          case "separator": {
+            return new DOMRect(50, 0, 10, 50);
+          }
+          case "right": {
+            return new DOMRect(60, 0, 50, 50);
+          }
+        }
+      });
+
+      const onLayoutChange = vi.fn();
+      const onLayoutChanged = vi.fn();
+
+      const { rerender } = render(
+        <Group
+          onLayoutChange={onLayoutChange}
+          onLayoutChanged={onLayoutChanged}
+        >
+          <Panel id="left" />
+          <Separator id="separator" />
+          <Panel id="right" />
+        </Group>
+      );
+
+      onLayoutChange.mockReset();
+      onLayoutChanged.mockReset();
+
+      rerender(
+        <Group
+          onLayoutChange={onLayoutChange}
+          onLayoutChanged={onLayoutChanged}
+        >
+          <Panel id="left" />
+          <Separator disabled id="separator" />
+          <Panel id="right" />
+        </Group>
+      );
+
+      // Resize attempts should be ignored because the Panel is disabled
+      await moveSeparator(25);
+      expect(onLayoutChange).not.toHaveBeenCalled();
+      expect(onLayoutChanged).not.toHaveBeenCalled();
+      onLayoutChange.mockReset();
+      onLayoutChanged.mockReset();
+
+      rerender(
+        <Group
+          onLayoutChange={onLayoutChange}
+          onLayoutChanged={onLayoutChanged}
+        >
+          <Panel id="left" />
+          <Separator id="separator" />
+          <Panel id="right" />
+        </Group>
+      );
+
+      // Resize attempts should work now that the Panel has been re-enabled
+      await moveSeparator(25);
+      expect(onLayoutChange).toHaveBeenCalled();
+      expect(onLayoutChanged).toHaveBeenCalled();
+    });
+  });
+
   describe("HTML attributes", () => {
     test("should expose id and data-testid", () => {
       render(

--- a/lib/global/dom/calculateHitRegions.ts
+++ b/lib/global/dom/calculateHitRegions.ts
@@ -10,7 +10,6 @@ import { calculateAvailableGroupSize } from "./calculateAvailableGroupSize";
 type PanelsTuple = [panel: RegisteredPanel, panel: RegisteredPanel];
 
 export type HitRegion = {
-  disabled: boolean;
   group: RegisteredGroup;
   groupSize: number;
   panels: PanelsTuple;
@@ -38,165 +37,197 @@ export function calculateHitRegions(group: RegisteredGroup) {
 
   const hitRegions: HitRegion[] = [];
 
-  let disabledPanel = false;
   let disabledSeparator = false;
   let hasInterleavedStaticContent = false;
+  let firstEnabledPanelIndex = -1;
+  let lastEnabledPanelIndex = -1;
+  let numEnabledPanels = 0;
   let prevPanel: RegisteredPanel | undefined = undefined;
   let pendingSeparators: RegisteredSeparator[] = [];
 
-  for (const childElement of sortedChildElements) {
-    if (childElement.hasAttribute("data-panel")) {
-      if (childElement.ariaDisabled !== null) {
-        disabledPanel = true;
+  {
+    let currentPanelIndex = -1;
+
+    for (const childElement of sortedChildElements) {
+      if (childElement.hasAttribute("data-panel")) {
+        currentPanelIndex++;
+
+        if (childElement.ariaDisabled === null) {
+          numEnabledPanels++;
+
+          if (firstEnabledPanelIndex === -1) {
+            firstEnabledPanelIndex = currentPanelIndex;
+          }
+
+          lastEnabledPanelIndex = currentPanelIndex;
+        }
       }
+    }
+  }
 
-      const panelData = panels.find(
-        (current) => current.element === childElement
-      );
-      if (panelData) {
-        if (prevPanel) {
-          const prevRect = prevPanel.element.getBoundingClientRect();
-          const rect = childElement.getBoundingClientRect();
+  // If all (or all but one) of the Panels are disabled, there can be no resize interactions.
+  if (numEnabledPanels > 1) {
+    let currentPanelIndex = -1;
 
-          let pendingRectsOrSeparators: (DOMRect | RegisteredSeparator)[];
+    for (const childElement of sortedChildElements) {
+      if (childElement.hasAttribute("data-panel")) {
+        currentPanelIndex++;
 
-          // If an explicit Separator has been rendered, always watch it
-          // Otherwise watch the entire space between the panels
-          // The one caveat is when there are non-interactive element(s) between panels,
-          // in which case we may need to watch individual panel edges
-          if (hasInterleavedStaticContent) {
-            const firstPanelEdgeRect =
-              orientation === "horizontal"
-                ? new DOMRect(prevRect.right, prevRect.top, 0, prevRect.height)
-                : new DOMRect(
-                    prevRect.left,
-                    prevRect.bottom,
-                    prevRect.width,
-                    0
-                  );
-            const secondPanelEdgeRect =
-              orientation === "horizontal"
-                ? new DOMRect(rect.left, rect.top, 0, rect.height)
-                : new DOMRect(rect.left, rect.top, rect.width, 0);
+        const panelData = panels.find(
+          (current) => current.element === childElement
+        );
+        if (panelData) {
+          if (prevPanel) {
+            const prevRect = prevPanel.element.getBoundingClientRect();
+            const rect = childElement.getBoundingClientRect();
 
-            switch (pendingSeparators.length) {
-              case 0: {
-                pendingRectsOrSeparators = [
-                  firstPanelEdgeRect,
-                  secondPanelEdgeRect
-                ];
-                break;
-              }
-              case 1: {
-                const separator = pendingSeparators[0];
-                const closestRect = findClosestRect({
-                  orientation,
-                  rects: [prevRect, rect],
-                  targetRect: separator.element.getBoundingClientRect()
-                });
+            let pendingRectsOrSeparators: (DOMRect | RegisteredSeparator)[];
 
-                pendingRectsOrSeparators = [
-                  separator,
-                  closestRect === prevRect
-                    ? secondPanelEdgeRect
-                    : firstPanelEdgeRect
-                ];
-                break;
-              }
-              default: {
-                pendingRectsOrSeparators = pendingSeparators;
-                break;
-              }
-            }
-          } else {
-            if (pendingSeparators.length) {
-              pendingRectsOrSeparators = pendingSeparators;
-            } else {
-              pendingRectsOrSeparators = [
+            // If an explicit Separator has been rendered, always watch it
+            // Otherwise watch the entire space between the panels
+            // The one caveat is when there are non-interactive element(s) between panels,
+            // in which case we may need to watch individual panel edges
+            if (hasInterleavedStaticContent) {
+              const firstPanelEdgeRect =
                 orientation === "horizontal"
                   ? new DOMRect(
                       prevRect.right,
-                      rect.top,
-                      rect.left - prevRect.right,
-                      rect.height
+                      prevRect.top,
+                      0,
+                      prevRect.height
                     )
                   : new DOMRect(
-                      rect.left,
+                      prevRect.left,
                       prevRect.bottom,
-                      rect.width,
-                      rect.top - prevRect.bottom
-                    )
-              ];
+                      prevRect.width,
+                      0
+                    );
+              const secondPanelEdgeRect =
+                orientation === "horizontal"
+                  ? new DOMRect(rect.left, rect.top, 0, rect.height)
+                  : new DOMRect(rect.left, rect.top, rect.width, 0);
+
+              switch (pendingSeparators.length) {
+                case 0: {
+                  pendingRectsOrSeparators = [
+                    firstPanelEdgeRect,
+                    secondPanelEdgeRect
+                  ];
+                  break;
+                }
+                case 1: {
+                  const separator = pendingSeparators[0];
+                  const closestRect = findClosestRect({
+                    orientation,
+                    rects: [prevRect, rect],
+                    targetRect: separator.element.getBoundingClientRect()
+                  });
+
+                  pendingRectsOrSeparators = [
+                    separator,
+                    closestRect === prevRect
+                      ? secondPanelEdgeRect
+                      : firstPanelEdgeRect
+                  ];
+                  break;
+                }
+                default: {
+                  pendingRectsOrSeparators = pendingSeparators;
+                  break;
+                }
+              }
+            } else {
+              if (pendingSeparators.length) {
+                pendingRectsOrSeparators = pendingSeparators;
+              } else {
+                pendingRectsOrSeparators = [
+                  orientation === "horizontal"
+                    ? new DOMRect(
+                        prevRect.right,
+                        rect.top,
+                        rect.left - prevRect.right,
+                        rect.height
+                      )
+                    : new DOMRect(
+                        rect.left,
+                        prevRect.bottom,
+                        rect.width,
+                        rect.top - prevRect.bottom
+                      )
+                ];
+              }
+            }
+
+            for (const rectOrSeparator of pendingRectsOrSeparators) {
+              let rect =
+                "width" in rectOrSeparator
+                  ? rectOrSeparator
+                  : rectOrSeparator.element.getBoundingClientRect();
+
+              const minHitTargetSize = isCoarsePointer()
+                ? group.resizeTargetMinimumSize.coarse
+                : group.resizeTargetMinimumSize.fine;
+              if (rect.width < minHitTargetSize) {
+                const delta = minHitTargetSize - rect.width;
+                rect = new DOMRect(
+                  rect.x - delta / 2,
+                  rect.y,
+                  rect.width + delta,
+                  rect.height
+                );
+              }
+              if (rect.height < minHitTargetSize) {
+                const delta = minHitTargetSize - rect.height;
+                rect = new DOMRect(
+                  rect.x,
+                  rect.y - delta / 2,
+                  rect.width,
+                  rect.height + delta
+                );
+              }
+
+              const skip =
+                currentPanelIndex <= firstEnabledPanelIndex ||
+                currentPanelIndex > lastEnabledPanelIndex;
+
+              if (!disabledSeparator && !skip) {
+                hitRegions.push({
+                  group,
+                  groupSize: calculateAvailableGroupSize({ group }),
+                  panels: [prevPanel, panelData],
+                  separator:
+                    "width" in rectOrSeparator ? undefined : rectOrSeparator,
+                  rect
+                });
+              }
+
+              disabledSeparator = false;
             }
           }
 
-          for (const rectOrSeparator of pendingRectsOrSeparators) {
-            let rect =
-              "width" in rectOrSeparator
-                ? rectOrSeparator
-                : rectOrSeparator.element.getBoundingClientRect();
-
-            const minHitTargetSize = isCoarsePointer()
-              ? group.resizeTargetMinimumSize.coarse
-              : group.resizeTargetMinimumSize.fine;
-            if (rect.width < minHitTargetSize) {
-              const delta = minHitTargetSize - rect.width;
-              rect = new DOMRect(
-                rect.x - delta / 2,
-                rect.y,
-                rect.width + delta,
-                rect.height
-              );
-            }
-            if (rect.height < minHitTargetSize) {
-              const delta = minHitTargetSize - rect.height;
-              rect = new DOMRect(
-                rect.x,
-                rect.y - delta / 2,
-                rect.width,
-                rect.height + delta
-              );
-            }
-
-            const hasSeparator = !("width" in rectOrSeparator);
-
-            hitRegions.push({
-              disabled: disabledSeparator || (disabledPanel && !hasSeparator),
-              group,
-              groupSize: calculateAvailableGroupSize({ group }),
-              panels: [prevPanel, panelData],
-              separator:
-                "width" in rectOrSeparator ? undefined : rectOrSeparator,
-              rect
-            });
-
-            disabledPanel = false;
-            disabledSeparator = false;
-          }
+          hasInterleavedStaticContent = false;
+          prevPanel = panelData;
+          pendingSeparators = [];
+        }
+      } else if (childElement.hasAttribute("data-separator")) {
+        if (childElement.ariaDisabled !== null) {
+          disabledSeparator = true;
         }
 
-        hasInterleavedStaticContent = false;
-        prevPanel = panelData;
-        pendingSeparators = [];
-      }
-    } else if (childElement.hasAttribute("data-separator")) {
-      if (childElement.ariaDisabled !== null) {
-        disabledSeparator = true;
-      }
-
-      const separatorData = separators.find(
-        (current) => current.element === childElement
-      );
-      if (separatorData) {
-        // Separators will be included implicitly in the area between the previous and next panel
-        // It's important to track them though, to handle the scenario of non-interactive group content
-        pendingSeparators.push(separatorData);
+        const separatorData = separators.find(
+          (current) => current.element === childElement
+        );
+        if (separatorData) {
+          // Separators will be included implicitly in the area between the previous and next panel
+          // It's important to track them though, to handle the scenario of non-interactive group content
+          pendingSeparators.push(separatorData);
+        } else {
+          prevPanel = undefined;
+          pendingSeparators = [];
+        }
       } else {
-        prevPanel = undefined;
-        pendingSeparators = [];
+        hasInterleavedStaticContent = true;
       }
-    } else {
-      hasInterleavedStaticContent = true;
     }
   }
 

--- a/lib/global/utils/adjustLayoutByDelta.test.ts
+++ b/lib/global/utils/adjustLayoutByDelta.test.ts
@@ -34,6 +34,7 @@ function c(partials: Partial<PanelConstraints>[]) {
       collapsedSize: 0,
       collapsible: false,
       defaultSize: undefined,
+      disabled: current.disabled,
       maxSize: 100,
       minSize: 0,
       ...current,
@@ -2473,6 +2474,27 @@ describe("adjustLayoutByDelta", () => {
             trigger: "mouse-or-touch"
           })
         ).toEqual(l([25, 50, 25]));
+      });
+    });
+
+    test("should be resizable via the imperative API", () => {
+      (
+        [
+          [-5, c([{ disabled: true }, {}]), l([45, 55])],
+          [5, c([{ disabled: true }, {}]), l([55, 45])],
+          [-5, c([{}, { disabled: true }]), l([45, 55])],
+          [5, c([{}, { disabled: true }]), l([55, 45])]
+        ] satisfies [number, PanelConstraints[], Layout][]
+      ).forEach(([delta, panelConstraints, expectedLayout]) => {
+        expect(
+          adjustLayoutByDelta({
+            delta,
+            initialLayout: l([50, 50]),
+            panelConstraints,
+            prevLayout: l([50, 50]),
+            trigger: "imperative-api"
+          })
+        ).toEqual(expectedLayout);
       });
     });
   });

--- a/lib/global/utils/adjustLayoutByDelta.ts
+++ b/lib/global/utils/adjustLayoutByDelta.ts
@@ -26,6 +26,8 @@ export function adjustLayoutByDelta({
     return initialLayoutProp;
   }
 
+  const overrideDisabledPanels = trigger === "imperative-api";
+
   const initialLayout = Object.values(initialLayoutProp);
   const prevLayout = Object.values(prevLayoutProp);
   const nextLayout = [...initialLayout];
@@ -210,6 +212,7 @@ export function adjustLayoutByDelta({
       );
 
       const maxSafeSize = validatePanelSize({
+        overrideDisabledPanels,
         panelConstraints: panelConstraintsArray[index],
         prevSize,
         size: 100
@@ -248,6 +251,7 @@ export function adjustLayoutByDelta({
 
       const unsafeSize = prevSize - deltaRemaining;
       const safeSize = validatePanelSize({
+        overrideDisabledPanels,
         panelConstraints: panelConstraintsArray[index],
         prevSize,
         size: unsafeSize
@@ -301,6 +305,7 @@ export function adjustLayoutByDelta({
 
     const unsafeSize = prevSize + deltaApplied;
     const safeSize = validatePanelSize({
+      overrideDisabledPanels,
       panelConstraints: panelConstraintsArray[pivotIndex],
       prevSize,
       size: unsafeSize
@@ -324,6 +329,7 @@ export function adjustLayoutByDelta({
 
         const unsafeSize = prevSize + deltaRemaining;
         const safeSize = validatePanelSize({
+          overrideDisabledPanels,
           panelConstraints: panelConstraintsArray[index],
           prevSize,
           size: unsafeSize

--- a/lib/global/utils/calculateDefaultLayout.test.ts
+++ b/lib/global/utils/calculateDefaultLayout.test.ts
@@ -8,6 +8,7 @@ const c = (
   collapsedSize: 0,
   collapsible: false,
   defaultSize: undefined,
+  disabled: undefined,
   maxSize: 100,
   minSize: 0,
   ...partial

--- a/lib/global/utils/calculateSeparatorAriaValues.test.ts
+++ b/lib/global/utils/calculateSeparatorAriaValues.test.ts
@@ -6,6 +6,7 @@ const DEFAULT_PANEL_CONSTRAINTS = {
   collapsedSize: 0,
   collapsible: false,
   defaultSize: undefined,
+  disabled: undefined,
   minSize: 0,
   maxSize: 100
 };
@@ -17,6 +18,7 @@ describe("calculateSeparatorAriaValues", () => {
         ...DEFAULT_PANEL_CONSTRAINTS,
         collapsedSize: 5,
         collapsible: true,
+        disabled: undefined,
         maxSize: 70,
         minSize: 20,
         panelId: "left"

--- a/lib/global/utils/findClosestHitRegion.ts
+++ b/lib/global/utils/findClosestHitRegion.ts
@@ -15,10 +15,6 @@ export function findClosestHitRegion(
   };
 
   for (const hitRegion of hitRegions) {
-    if (hitRegion.disabled) {
-      continue;
-    }
-
     const data = getDistanceBetweenPointAndRect(point, hitRegion.rect);
     switch (orientation) {
       case "horizontal": {

--- a/lib/global/utils/getImperativeGroupMethods.test.ts
+++ b/lib/global/utils/getImperativeGroupMethods.test.ts
@@ -155,5 +155,32 @@ describe("getImperativeGroupMethods", () => {
         "A-2": 70
       });
     });
+
+    test("allows disabled panels to be resized", () => {
+      const { api } = init([
+        { defaultSize: 200, disabled: true, minSize: 100 },
+        { defaultSize: 800, disabled: true }
+      ]);
+
+      expect(api.getLayout()).toMatchInlineSnapshot(`
+        {
+          "A-1": 20,
+          "A-2": 80,
+        }
+      `);
+
+      api.setLayout({
+        "A-1": 30,
+        "A-2": 70
+      });
+
+      expect(onMountedGroupsChange).toHaveBeenCalledTimes(1);
+      expect(api.getLayout()).toMatchInlineSnapshot(`
+        {
+          "A-1": 30,
+          "A-2": 70,
+        }
+      `);
+    });
   });
 });

--- a/lib/global/utils/getImperativePanelMethods.test.ts
+++ b/lib/global/utils/getImperativePanelMethods.test.ts
@@ -56,7 +56,14 @@ describe("getImperativePanelMethods", () => {
       const group = mockGroup(bounds, "horizontal", "A");
 
       panelConstraints.forEach(
-        ({ collapsedSize, collapsible, defaultSize, maxSize, minSize }) => {
+        ({
+          collapsedSize,
+          collapsible,
+          defaultSize,
+          disabled,
+          maxSize,
+          minSize
+        }) => {
           group.addPanel(
             new DOMRect(
               0,
@@ -73,6 +80,7 @@ describe("getImperativePanelMethods", () => {
               collapsible,
               defaultSize:
                 defaultSize !== undefined ? `${defaultSize}%` : undefined,
+              disabled,
               maxSize: maxSize !== undefined ? `${maxSize}%` : undefined,
               minSize: minSize !== undefined ? `${minSize}%` : 0
             }
@@ -152,6 +160,21 @@ describe("getImperativePanelMethods", () => {
         expect(onLayoutChange).toHaveBeenCalledTimes(1);
         expect(onLayoutChange).toHaveBeenCalledWith([0, 100]);
       });
+
+      test("allows disabled panel to be collapsed", () => {
+        const { panelApis } = init([
+          {
+            collapsible: true,
+            defaultSize: 50,
+            disabled: true
+          },
+          {}
+        ]);
+        panelApis[0].collapse();
+
+        expect(onLayoutChange).toHaveBeenCalledTimes(1);
+        expect(onLayoutChange).toHaveBeenCalledWith([0, 100]);
+      });
     });
 
     describe("expand", () => {
@@ -212,6 +235,17 @@ describe("getImperativePanelMethods", () => {
 
         expect(onLayoutChange).toHaveBeenCalledTimes(1);
         expect(onLayoutChange).toHaveBeenCalledWith([1, 99]);
+      });
+
+      test("allows disabled panel to be expanded", () => {
+        const { panelApis } = init([
+          { defaultSize: 0, collapsible: true, disabled: true, minSize: 10 },
+          {}
+        ]);
+
+        panelApis[0].expand();
+        expect(onLayoutChange).toHaveBeenCalledTimes(1);
+        expect(onLayoutChange).toHaveBeenCalledWith([10, 90]);
       });
     });
 
@@ -277,6 +311,18 @@ describe("getImperativePanelMethods", () => {
 
       test("validates and updates the panel size", () => {
         const { panelApis } = init([{ defaultSize: 25, minSize: 10 }, {}]);
+        panelApis[0].resize(0);
+
+        expect(onLayoutChange).toHaveBeenCalledTimes(1);
+        expect(onLayoutChange).toHaveBeenCalledWith([10, 90]);
+      });
+
+      test("allows disabled panel to be resized", () => {
+        const { panelApis } = init([
+          { defaultSize: 25, disabled: true, minSize: 10 },
+          {}
+        ]);
+
         panelApis[0].resize(0);
 
         expect(onLayoutChange).toHaveBeenCalledTimes(1);

--- a/lib/global/utils/validatePanelGroupLayout.test.ts
+++ b/lib/global/utils/validatePanelGroupLayout.test.ts
@@ -11,6 +11,7 @@ function c(partials: Partial<PanelConstraints>[]) {
       collapsedSize: 0,
       collapsible: false,
       defaultSize: undefined,
+      disabled: undefined,
       maxSize: 100,
       minSize: 0,
       ...current,

--- a/lib/global/utils/validatePanelGroupLayout.ts
+++ b/lib/global/utils/validatePanelGroupLayout.ts
@@ -50,6 +50,7 @@ export function validatePanelGroupLayout({
     assert(unsafeSize != null, `No layout data found for index ${index}`);
 
     const safeSize = validatePanelSize({
+      overrideDisabledPanels: true,
       panelConstraints: panelConstraints[index],
       prevSize,
       size: unsafeSize
@@ -70,6 +71,7 @@ export function validatePanelGroupLayout({
       assert(prevSize != null, `No layout data found for index ${index}`);
       const unsafeSize = prevSize + remainingSize;
       const safeSize = validatePanelSize({
+        overrideDisabledPanels: true,
         panelConstraints: panelConstraints[index],
         prevSize,
         size: unsafeSize

--- a/lib/global/utils/validatePanelSize.ts
+++ b/lib/global/utils/validatePanelSize.ts
@@ -4,10 +4,12 @@ import { formatLayoutNumber } from "./formatLayoutNumber";
 
 // Panel size must be in percentages; pixel values should be pre-converted
 export function validatePanelSize({
+  overrideDisabledPanels,
   panelConstraints,
   prevSize,
   size
 }: {
+  overrideDisabledPanels?: boolean;
   panelConstraints: PanelConstraints;
   prevSize: number;
   size: number;
@@ -20,7 +22,7 @@ export function validatePanelSize({
     minSize = 0
   } = panelConstraints;
 
-  if (disabled) {
+  if (disabled && !overrideDisabledPanels) {
     return prevSize;
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -227,7 +227,8 @@ const commonQuestions: CommonQuestion[] = [
         <Code html={ConditionallyRenderPanel} />
         <Callout>
           Putting the <code>defaultSize</code> on the conditional{" "}
-          <code>Panel</code> is an easy way to avoid invalid layout constraints.
+          <code>Panel</code> is the easiest way to avoid invalid layout
+          constraints in this type of scenario.
         </Callout>
       </>
     )

--- a/src/components/accordion/AccordionGroup.tsx
+++ b/src/components/accordion/AccordionGroup.tsx
@@ -1,0 +1,11 @@
+import { type PropsWithChildren } from "react";
+import { Group, Panel } from "react-resizable-panels";
+
+export function AccordionGroup({ children }: PropsWithChildren) {
+  return (
+    <Group className="h-35! gap-1">
+      {children}
+      <Panel className="flex flex-row rounded bg-slate-800" />
+    </Group>
+  );
+}

--- a/src/components/accordion/AccordionPanel.tsx
+++ b/src/components/accordion/AccordionPanel.tsx
@@ -1,0 +1,35 @@
+import { useState, type PropsWithChildren } from "react";
+import { Panel } from "react-resizable-panels";
+
+export function AccordionPanel({
+  children,
+  index
+}: PropsWithChildren<{
+  index: number;
+}>) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  return (
+    <Panel
+      className="flex flex-row rounded bg-slate-700"
+      disabled={isCollapsed}
+      id={"" + index}
+      maxSize={isCollapsed ? 18 : undefined}
+      minSize={isCollapsed ? 18 : 100}
+    >
+      <div
+        className="bg-slate-600 rounded px-1 h-full w-6 shrink-0 text-center cursor-pointer"
+        onClick={() => {
+          setIsCollapsed(!isCollapsed);
+        }}
+      >
+        {index}
+      </div>
+      {isCollapsed || (
+        <div className="w-full overflow-hidden flex items-center justify-center">
+          {children}
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/src/routes/DisabledPanelsRoute.tsx
+++ b/src/routes/DisabledPanelsRoute.tsx
@@ -1,8 +1,9 @@
 import { Box, Callout, Code, Header } from "react-lib-tools";
-import { html as DisabledSeparatorHTML } from "../../public/generated/examples/DisabledSeparator.json";
-import { html as DisabledPanelsHTML } from "../../public/generated/examples/DisabledPanels.json";
 import { html as DisabledPanelHTML } from "../../public/generated/examples/DisabledPanel.json";
 import { html as DisabledPanelAndSeparatorHTML } from "../../public/generated/examples/DisabledPanelAndSeparator.json";
+import { html as DisabledPanelsHTML } from "../../public/generated/examples/DisabledPanels.json";
+import { html as DisabledSeparatorHTML } from "../../public/generated/examples/DisabledSeparator.json";
+import { Link } from "../components/Link";
 import { Group } from "../components/styled-panels/Group";
 import { Panel } from "../components/styled-panels/Panel";
 import { Separator } from "../components/styled-panels/Separator";
@@ -22,9 +23,9 @@ export default function DisabledPanelsRoute() {
       </div>
       <Code html={DisabledSeparatorHTML} />
       <Group>
-        <Panel>left</Panel>
+        <Panel minSize={50}>left</Panel>
         <Separator disabled />
-        <Panel>right</Panel>
+        <Panel minSize={50}>right</Panel>
       </Group>
       <div>
         The same applies to disabling one or both panels when there is no
@@ -36,8 +37,12 @@ export default function DisabledPanelsRoute() {
       </Callout>
       <Code html={DisabledPanelsHTML} />
       <Group>
-        <Panel disabled>left</Panel>
-        <Panel disabled>right</Panel>
+        <Panel disabled minSize={50}>
+          left
+        </Panel>
+        <Panel disabled minSize={50}>
+          right
+        </Panel>
       </Group>
       <div>
         In groups with three or more panels, disabling a separator does not
@@ -46,11 +51,11 @@ export default function DisabledPanelsRoute() {
         resized as well.
       </div>
       <Group>
-        <Panel>left</Panel>
+        <Panel minSize={50}>left</Panel>
         <Separator disabled />
-        <Panel>center</Panel>
+        <Panel minSize={50}>center</Panel>
         <Separator />
-        <Panel>right</Panel>
+        <Panel minSize={50}>right</Panel>
       </Group>
       <div>
         Disabling a panel prevents it from being resized, though its separator
@@ -58,11 +63,24 @@ export default function DisabledPanelsRoute() {
       </div>
       <Code html={DisabledPanelHTML} />
       <Group>
-        <Panel>left</Panel>
+        <Panel minSize={50}>left</Panel>
         <Separator />
-        <Panel disabled>center (disabled)</Panel>
+        <Panel disabled minSize={50}>
+          center (disabled)
+        </Panel>
         <Separator />
-        <Panel>right</Panel>
+        <Panel minSize={50}>right</Panel>
+      </Group>
+      <div>
+        When there is no separator, a disabled panel's edges can also be used to
+        resize other panels.
+      </div>
+      <Group>
+        <Panel minSize={50}>left</Panel>
+        <Panel disabled minSize={50}>
+          center (disabled)
+        </Panel>
+        <Panel minSize={50}>right</Panel>
       </Group>
       <div>
         You can also disable both a panel and its separator to completely
@@ -70,12 +88,18 @@ export default function DisabledPanelsRoute() {
       </div>
       <Code html={DisabledPanelAndSeparatorHTML} />
       <Group>
-        <Panel disabled>left (disabled)</Panel>
+        <Panel disabled minSize={50}>
+          left (disabled)
+        </Panel>
         <Separator disabled />
-        <Panel>center</Panel>
+        <Panel minSize={50}>center</Panel>
         <Separator />
-        <Panel>right</Panel>
+        <Panel minSize={50}>right</Panel>
       </Group>
+      <Callout intent="primary">
+        Note that a disabled <code>Panel</code> can still be resized using the{" "}
+        <Link to="/imperative-api/panel">imperative API</Link>.
+      </Callout>
     </Box>
   );
 }

--- a/src/routes/LayoutBasicsRoute.tsx
+++ b/src/routes/LayoutBasicsRoute.tsx
@@ -34,7 +34,7 @@ export default function LayoutBasicsRoute() {
         <Link anchor="vertical-group-height" to="/common-questions">
           read more
         </Link>
-        ) .
+        ).
       </Callout>
       <Group className="min-h-30" orientation="vertical">
         <Panel>top</Panel>

--- a/src/routes/TestRoute.tsx
+++ b/src/routes/TestRoute.tsx
@@ -1,21 +1,19 @@
-import { Fragment } from "react";
-import { Box, Callout, ExternalLink, type Intent } from "react-lib-tools";
+import { Box } from "react-lib-tools";
+import { AccordionGroup } from "../components/accordion/AccordionGroup";
+import { AccordionPanel } from "../components/accordion/AccordionPanel";
 
 export default function TestRoute() {
   return (
-    <Box direction="column" gap={2}>
-      {INTENTS.map((intent) => (
-        <Fragment key={intent}>
-          <Callout intent={intent}>
-            Text and <ExternalLink href="#">link text</ExternalLink>.
-          </Callout>
-          <Callout intent={intent} minimal>
-            Text and <ExternalLink href="#">link text</ExternalLink>.
-          </Callout>
-        </Fragment>
-      ))}
+    <Box className="m-2" direction="column" gap={1}>
+      <div>
+        This is a test route. Any content shown here is temporary and should not
+        be referenced externally.
+      </div>
+      <AccordionGroup>
+        <AccordionPanel index={1}>This is the first panel.</AccordionPanel>
+        <AccordionPanel index={2}>This is the second panel.</AccordionPanel>
+        <AccordionPanel index={3}>This is the third panel.</AccordionPanel>
+      </AccordionGroup>
     </Box>
   );
 }
-
-const INTENTS: Intent[] = ["none", "primary", "success", "warning", "danger"];


### PR DESCRIPTION
Follow up to #604

- Imperative `Panel` and `Group` APIs ignored `disabled` status when resizing panels; this is an explicit override of the _disabled_ state and is required to support conditionally disabled groups.
- `Separator` component does not set a `cursor: not-allowed` style if the parent `Group` has cursors disabled.