### PR TITLE
fix: add touch-action: none to Separator for touch device support Fixes #662

### DIFF
--- a/lib/components/separator/Separator.tsx
+++ b/lib/components/separator/Separator.tsx
@@ -162,7 +162,8 @@ export function Separator({
         cursor,
         ...style,
         flexGrow: 0,
-        flexShrink: 0
+        flexShrink: 0,
+        touchAction: "none" // Disable touch scrolling while dragging
       }}
       tabIndex={disabled ? undefined : 0}
     />


### PR DESCRIPTION
## Description

Fixes #662 

This PR resolves an issue where dragging the resizable handle on touch devices (tablets and mobile phones) caused the panel to jump or snap to the edge of the container, making it impossible to resize panels accurately with touch interactions.

## Root Cause

The issue was caused by the browser's default touch gesture handling. When a user attempted to drag the resize handle on a touch device, the browser would interpret the touch movement as a potential scroll or pan gesture and fire a `pointercancel` event, which interrupted the drag operation and caused erratic behavior.

## Solution

Added `touch-action: none` CSS property to the `Separator` component. This CSS property instructs the browser to disable all default touch behaviors (scrolling, zooming, panning) on the resize handle element, allowing the pointer events to be handled exclusively by the resize logic.

The `touch-action: none` property:
- Prevents the browser from firing `pointercancel` events during drag operations
- Ensures smooth and continuous pointer tracking during touch interactions
- Does not affect mouse-based interactions
- Is the standard approach for implementing custom drag interactions on touch devices

## Changes

- Added `touchAction: "none"` to the `Separator` component's inline styles

## Testing

Tested on:
- ✅ Android devices (Chrome browser)
- ✅ Chrome DevTools mobile emulation
- ✅ Desktop browsers (Chrome, Firefox) - no regression
- ⚠️ iOS devices - not tested (would appreciate testing from reviewers)

### Before
- Touch dragging caused panels to jump to extreme positions
- Resize handle was unresponsive or erratic on touch devices
- Drag operations would randomly stop mid-gesture

### After
- Smooth, predictable touch dragging behavior
- Resize handle follows finger movement accurately
- Consistent behavior across touch and mouse interactions

## Breaking Changes

None. This is a bug fix that only affects the CSS styling of the resize handle.

## Additional Notes

This is a minimal, non-invasive fix that follows web standards for handling touch interactions in custom drag operations. The `touch-action` CSS property is widely supported across all modern browsers.

If there are concerns about iOS compatibility, I'm happy to add additional testing or iterate on the solution. However, `touch-action: none` is the standard approach recommended by MDN and browser vendors for preventing default touch behaviors during custom pointer interactions.
```

## Commit Message
```
fix: add touch-action: none to Separator for touch device support

Fixes #662

On touch devices, the browser's default gesture handling would fire
pointercancel events during drag operations, causing panels to jump
to extreme positions. Adding touch-action: none prevents the browser
from interpreting touch movements as gestures, allowing smooth touch
dragging.

Tested on Android devices and Chrome DevTools mobile emulation.
```

## Files Changed
```
lib/components/separator/Separator.tsx