### PR TITLE
fix: edge case collapse last panel

### DIFF
--- a/lib/global/utils/getImperativePanelMethods.test.ts
+++ b/lib/global/utils/getImperativePanelMethods.test.ts
@@ -375,6 +375,42 @@ describe("getImperativePanelMethods", () => {
         expect(onLayoutChange).toHaveBeenCalledTimes(1);
         expect(onLayoutChange).toHaveBeenCalledWith([10, 90]);
       });
+
+      describe("edge cases", () => {
+        test("does not throw when resizing the only panel in the group", () => {
+          const { panelApis } = init([{ defaultSize: 100 }]);
+
+          expect(() => panelApis[0].resize("50%")).not.toThrow();
+          expect(onLayoutChange).not.toHaveBeenCalled();
+        });
+
+        test("last panel keeps the remainder when all preceding panels are collapsed and it is resized smaller", () => {
+          const { panelApis } = init([
+            { collapsible: true, defaultSize: 0, minSize: 20 },
+            { collapsible: true, defaultSize: 0, minSize: 20 },
+            { defaultSize: 100 }
+          ]);
+
+          panelApis[2].resize("50%");
+
+          // The last panel should remain at 100% (the remainder) rather than
+          // cascading the freed space to the first panel.
+          expect(onLayoutChange).not.toHaveBeenCalled();
+        });
+
+        test("last panel can still be resized normally when preceding panels are not all collapsed", () => {
+          const { panelApis } = init([
+            { defaultSize: 30 },
+            { defaultSize: 30 },
+            { defaultSize: 40 }
+          ]);
+
+          panelApis[2].resize("20%");
+
+          expect(onLayoutChange).toHaveBeenCalledTimes(1);
+          expect(onLayoutChange).toHaveBeenCalledWith([30, 50, 20]);
+        });
+      });
     });
   });
 });

--- a/lib/global/utils/getImperativePanelMethods.ts
+++ b/lib/global/utils/getImperativePanelMethods.ts
@@ -116,10 +116,7 @@ export function getImperativePanelMethods({
           .slice(0, index)
           .reduce((total, panel) => total + prevLayout[panel.id], 0);
 
-        const fallbackLayout: Record<string, number> = {};
-        for (const key of Object.keys(prevLayout)) {
-          fallbackLayout[key] = prevLayout[key];
-        }
+        const fallbackLayout = { ...prevLayout };
         fallbackLayout[panelId] = formatLayoutNumber(100 - occupiedByPrevious);
 
         const nextLayout = validatePanelGroupLayout({

--- a/lib/global/utils/getImperativePanelMethods.ts
+++ b/lib/global/utils/getImperativePanelMethods.ts
@@ -1,4 +1,8 @@
-import type { PanelImperativeHandle } from "../../components/panel/types";
+import type { Layout } from "../../components/group/types";
+import type {
+  PanelConstraints,
+  PanelImperativeHandle
+} from "../../components/panel/types";
 import { calculateAvailableGroupSize } from "../dom/calculateAvailableGroupSize";
 import { getMountedGroups, updateMountedGroup } from "../mutable-state/groups";
 import { sizeStyleToPixels } from "../styles/sizeStyleToPixels";
@@ -71,6 +75,61 @@ export function getImperativePanelMethods({
     throw Error(`Layout not found for Panel ${panelId}`);
   };
 
+  /**
+   * Compute the next (unvalidated) layout when resizing a panel imperatively.
+   *
+   * Handles the edge case where the last panel is being collapsed but all
+   * preceding panels are already collapsed — the normal reversed-delta logic
+   * would cascade the freed space to the first panel. Instead the last panel
+   * keeps the remainder so it stays the largest.
+   */
+  const computeLayout = ({
+    nextSize,
+    panels,
+    prevLayout,
+    derivedPanelConstraints
+  }: {
+    nextSize: number;
+    panels: { id: string }[];
+    prevLayout: Layout;
+    derivedPanelConstraints: PanelConstraints[];
+  }): Layout => {
+    const prevSize = getPanelSize();
+
+    const index = panels.findIndex((current) => current.id === panelId);
+    const isLastPanel = index === panels.length - 1;
+
+    if (
+      isLastPanel &&
+      nextSize < prevSize &&
+      index > 0 &&
+      panels.slice(0, index).every((_panel, panelIndex) => {
+        const pc = derivedPanelConstraints[panelIndex];
+        return (
+          pc?.collapsible &&
+          layoutNumbersEqual(pc.collapsedSize, prevLayout[pc.panelId])
+        );
+      })
+    ) {
+      const occupiedByPrevious = panels
+        .slice(0, index)
+        .reduce((total, panel) => total + prevLayout[panel.id], 0);
+      return {
+        ...prevLayout,
+        [panelId]: formatLayoutNumber(100 - occupiedByPrevious)
+      };
+    }
+
+    return adjustLayoutByDelta({
+      delta: isLastPanel ? prevSize - nextSize : nextSize - prevSize,
+      initialLayout: prevLayout,
+      panelConstraints: derivedPanelConstraints,
+      pivotIndices: isLastPanel ? [index - 1, index] : [index, index + 1],
+      prevLayout,
+      trigger: "imperative-api"
+    });
+  };
+
   const setPanelSize = (nextSize: number) => {
     const prevSize = getPanelSize();
     if (nextSize === prevSize) {
@@ -86,42 +145,12 @@ export function getImperativePanelMethods({
       separatorToPanels
     } = find();
 
-    const index = group.panels.findIndex((current) => current.id === panelId);
-    const isLastPanel = index === group.panels.length - 1;
-
-    // Edge case: collapsing the last panel when all previous panels are already
-    // collapsed. The normal last-panel logic reverses delta/pivot so the panel
-    // before absorbs freed space, but when every prior panel is collapsed the
-    // space cascades all the way to the first panel. Instead, keep the last
-    // panel as the remainder recipient by computing the layout directly.
-    let unsafeLayout;
-    if (
-      isLastPanel &&
-      nextSize < prevSize &&
-      index > 0 &&
-      group.panels.slice(0, index).every((_panel, panelIndex) => {
-        const pc = derivedPanelConstraints[panelIndex];
-        return (
-          pc?.collapsible &&
-          layoutNumbersEqual(pc.collapsedSize, prevLayout[pc.panelId])
-        );
-      })
-    ) {
-      const occupiedByPrevious = group.panels
-        .slice(0, index)
-        .reduce((total, panel) => total + prevLayout[panel.id], 0);
-      unsafeLayout = { ...prevLayout };
-      unsafeLayout[panelId] = formatLayoutNumber(100 - occupiedByPrevious);
-    } else {
-      unsafeLayout = adjustLayoutByDelta({
-        delta: isLastPanel ? prevSize - nextSize : nextSize - prevSize,
-        initialLayout: prevLayout,
-        panelConstraints: derivedPanelConstraints,
-        pivotIndices: isLastPanel ? [index - 1, index] : [index, index + 1],
-        prevLayout,
-        trigger: "imperative-api"
-      });
-    }
+    const unsafeLayout = computeLayout({
+      nextSize,
+      panels: group.panels,
+      prevLayout,
+      derivedPanelConstraints
+    });
 
     const nextLayout = validatePanelGroupLayout({
       layout: unsafeLayout,

--- a/lib/global/utils/getImperativePanelMethods.ts
+++ b/lib/global/utils/getImperativePanelMethods.ts
@@ -88,6 +88,53 @@ export function getImperativePanelMethods({
 
     const index = group.panels.findIndex((current) => current.id === panelId);
     const isLastPanel = index === group.panels.length - 1;
+    const isCollapsing = nextSize < prevSize;
+
+    // Edge case: collapsing the last panel when all previous panels are already
+    // collapsed. The normal last-panel logic reverses delta/pivot so the panel
+    // before absorbs freed space, but when every prior panel is collapsed the
+    // space cascades all the way to the first panel. Instead, keep the last
+    // panel as the remainder recipient.
+    if (isLastPanel && isCollapsing && index > 0) {
+      const allPreviousCollapsed = group.panels
+        .slice(0, index)
+        .every((_panel, panelIndex) => {
+          const pc = derivedPanelConstraints[panelIndex];
+          return (
+            pc?.collapsible === true &&
+            layoutNumbersEqual(pc.collapsedSize, prevLayout[pc.panelId])
+          );
+        });
+
+      if (allPreviousCollapsed) {
+        // Build layout keeping every prior panel as-is; the last panel gets
+        // whatever remains so the total stays at 100%.
+        const occupiedByPrevious = group.panels
+          .slice(0, index)
+          .reduce((total, panel) => total + prevLayout[panel.id], 0);
+
+        const fallbackLayout: Record<string, number> = {};
+        for (const key of Object.keys(prevLayout)) {
+          fallbackLayout[key] = prevLayout[key];
+        }
+        fallbackLayout[panelId] = formatLayoutNumber(100 - occupiedByPrevious);
+
+        const nextLayout = validatePanelGroupLayout({
+          layout: fallbackLayout,
+          panelConstraints: derivedPanelConstraints
+        });
+        if (!layoutsEqual(prevLayout, nextLayout)) {
+          updateMountedGroup(group, {
+            defaultLayoutDeferred,
+            derivedPanelConstraints,
+            groupSize,
+            layout: nextLayout,
+            separatorToPanels
+          });
+        }
+        return;
+      }
+    }
 
     const unsafeLayout = adjustLayoutByDelta({
       delta: isLastPanel ? prevSize - nextSize : nextSize - prevSize,

--- a/lib/global/utils/getImperativePanelMethods.ts
+++ b/lib/global/utils/getImperativePanelMethods.ts
@@ -99,10 +99,13 @@ export function getImperativePanelMethods({
       const allPreviousCollapsed = group.panels
         .slice(0, index)
         .every((_panel, panelIndex) => {
-          const pc = derivedPanelConstraints[panelIndex];
+          const panelConstraints = derivedPanelConstraints[panelIndex];
           return (
-            pc?.collapsible === true &&
-            layoutNumbersEqual(pc.collapsedSize, prevLayout[pc.panelId])
+            panelConstraints?.collapsible &&
+            layoutNumbersEqual(
+              panelConstraints.collapsedSize,
+              prevLayout[panelConstraints.panelId]
+            )
           );
         });
 

--- a/lib/global/utils/getImperativePanelMethods.ts
+++ b/lib/global/utils/getImperativePanelMethods.ts
@@ -88,62 +88,40 @@ export function getImperativePanelMethods({
 
     const index = group.panels.findIndex((current) => current.id === panelId);
     const isLastPanel = index === group.panels.length - 1;
-    const isCollapsing = nextSize < prevSize;
 
     // Edge case: collapsing the last panel when all previous panels are already
     // collapsed. The normal last-panel logic reverses delta/pivot so the panel
     // before absorbs freed space, but when every prior panel is collapsed the
     // space cascades all the way to the first panel. Instead, keep the last
-    // panel as the remainder recipient.
-    if (isLastPanel && isCollapsing && index > 0) {
-      const allPreviousCollapsed = group.panels
+    // panel as the remainder recipient by computing the layout directly.
+    let unsafeLayout;
+    if (
+      isLastPanel &&
+      nextSize < prevSize &&
+      index > 0 &&
+      group.panels.slice(0, index).every((_panel, panelIndex) => {
+        const pc = derivedPanelConstraints[panelIndex];
+        return (
+          pc?.collapsible &&
+          layoutNumbersEqual(pc.collapsedSize, prevLayout[pc.panelId])
+        );
+      })
+    ) {
+      const occupiedByPrevious = group.panels
         .slice(0, index)
-        .every((_panel, panelIndex) => {
-          const panelConstraints = derivedPanelConstraints[panelIndex];
-          return (
-            panelConstraints?.collapsible &&
-            layoutNumbersEqual(
-              panelConstraints.collapsedSize,
-              prevLayout[panelConstraints.panelId]
-            )
-          );
-        });
-
-      if (allPreviousCollapsed) {
-        // Build layout keeping every prior panel as-is; the last panel gets
-        // whatever remains so the total stays at 100%.
-        const occupiedByPrevious = group.panels
-          .slice(0, index)
-          .reduce((total, panel) => total + prevLayout[panel.id], 0);
-
-        const fallbackLayout = { ...prevLayout };
-        fallbackLayout[panelId] = formatLayoutNumber(100 - occupiedByPrevious);
-
-        const nextLayout = validatePanelGroupLayout({
-          layout: fallbackLayout,
-          panelConstraints: derivedPanelConstraints
-        });
-        if (!layoutsEqual(prevLayout, nextLayout)) {
-          updateMountedGroup(group, {
-            defaultLayoutDeferred,
-            derivedPanelConstraints,
-            groupSize,
-            layout: nextLayout,
-            separatorToPanels
-          });
-        }
-        return;
-      }
+        .reduce((total, panel) => total + prevLayout[panel.id], 0);
+      unsafeLayout = { ...prevLayout };
+      unsafeLayout[panelId] = formatLayoutNumber(100 - occupiedByPrevious);
+    } else {
+      unsafeLayout = adjustLayoutByDelta({
+        delta: isLastPanel ? prevSize - nextSize : nextSize - prevSize,
+        initialLayout: prevLayout,
+        panelConstraints: derivedPanelConstraints,
+        pivotIndices: isLastPanel ? [index - 1, index] : [index, index + 1],
+        prevLayout,
+        trigger: "imperative-api"
+      });
     }
-
-    const unsafeLayout = adjustLayoutByDelta({
-      delta: isLastPanel ? prevSize - nextSize : nextSize - prevSize,
-      initialLayout: prevLayout,
-      panelConstraints: derivedPanelConstraints,
-      pivotIndices: isLastPanel ? [index - 1, index] : [index, index + 1],
-      prevLayout,
-      trigger: "imperative-api"
-    });
 
     const nextLayout = validatePanelGroupLayout({
       layout: unsafeLayout,

--- a/lib/global/utils/getImperativePanelMethods.ts
+++ b/lib/global/utils/getImperativePanelMethods.ts
@@ -79,10 +79,11 @@ export function getImperativePanelMethods({
   /**
    * Compute the next (unvalidated) layout when resizing a panel imperatively.
    *
-   * Handles the edge case where the last panel is being collapsed but all
-   * preceding panels are already collapsed — the normal reversed-delta logic
-   * would cascade the freed space to the first panel. Instead the last panel
-   * keeps the remainder so it stays the largest.
+   * Handles two edge cases for the last panel:
+   * 1. Single panel in the group — no sibling exists to form valid pivot indices.
+   * 2. All preceding panels are already collapsed — the normal reversed-delta
+   *    logic would cascade the freed space to the first panel. Instead the last
+   *    panel keeps the remainder so it stays the largest.
    */
   const computeLayout = ({
     nextSize,
@@ -98,20 +99,22 @@ export function getImperativePanelMethods({
     const prevSize = getPanelSize();
 
     const index = panels.findIndex((current) => current.id === panelId);
+    const isFirstPanel = index === 0;
     const isLastPanel = index === panels.length - 1;
 
-    if (
+    const allPreviousCollapsed =
       isLastPanel &&
       nextSize < prevSize &&
-      index > 0 &&
-      panels.slice(0, index).every((_panel, panelIndex) => {
-        const pc = derivedPanelConstraints[panelIndex];
-        return (
-          pc?.collapsible &&
-          layoutNumbersEqual(pc.collapsedSize, prevLayout[pc.panelId])
-        );
-      })
-    ) {
+      (isFirstPanel ||
+        panels.slice(0, index).every((_panel, panelIndex) => {
+          const pc = derivedPanelConstraints[panelIndex];
+          return (
+            pc?.collapsible &&
+            layoutNumbersEqual(pc.collapsedSize, prevLayout[pc.panelId])
+          );
+        }));
+
+    if (allPreviousCollapsed) {
       const occupiedByPrevious = panels
         .slice(0, index)
         .reduce((total, panel) => total + prevLayout[panel.id], 0);

--- a/lib/global/utils/getImperativePanelMethods.ts
+++ b/lib/global/utils/getImperativePanelMethods.ts
@@ -1,7 +1,8 @@
 import type { Layout } from "../../components/group/types";
 import type {
   PanelConstraints,
-  PanelImperativeHandle
+  PanelImperativeHandle,
+  RegisteredPanel
 } from "../../components/panel/types";
 import { calculateAvailableGroupSize } from "../dom/calculateAvailableGroupSize";
 import { getMountedGroups, updateMountedGroup } from "../mutable-state/groups";
@@ -90,7 +91,7 @@ export function getImperativePanelMethods({
     derivedPanelConstraints
   }: {
     nextSize: number;
-    panels: { id: string }[];
+    panels: RegisteredPanel[];
     prevLayout: Layout;
     derivedPanelConstraints: PanelConstraints[];
   }): Layout => {


### PR DESCRIPTION
When collapsing the a panel within a group where all other (previous) panels are already collapsed, there's currently a bug where the delta calculation cascades to cause the first panel to expand. This is undesired since the first panel should remain collapsed given we are not touching it.

This fix handles the edge case by computing the remaining space percentage for the last panel to take up, thus leaving previous panels undisturbed.

By "previous" panels here I mean panels above (vertical mode) or to the left (horizontal) mode.