### PR TITLE
Fixed Panel condition to properly handle explicit defaultSize

### DIFF
--- a/integrations/next/app/page.tsx
+++ b/integrations/next/app/page.tsx
@@ -65,11 +65,12 @@ export default async function Home() {
       <DefaultSize defaultSize="100px" />
       <DefaultSize defaultSize="25vw" />
       <DefaultSize defaultSize="15rem" />
+      <DefaultSize defaultSize={0} />
     </div>
   );
 }
 
-function DefaultSize({ defaultSize }: { defaultSize: string }) {
+function DefaultSize({ defaultSize }: { defaultSize: number | string }) {
   return (
     <Group className="h-25 gap-2">
       <Panel className="bg-slate-800 rounded rounded-md p-2" id="left">

--- a/integrations/tests/src/components/LayoutShiftDetecter.tsx
+++ b/integrations/tests/src/components/LayoutShiftDetecter.tsx
@@ -26,7 +26,7 @@ export function LayoutShiftDetecter() {
   useEffect(() => {
     const timeout = setTimeout(() => {
       setState((prevState) => (prevState === null ? 0 : prevState));
-    }, 250);
+    }, 100);
 
     return () => {
       clearTimeout(timeout);

--- a/integrations/tests/tests/default-layout.spec.tsx
+++ b/integrations/tests/tests/default-layout.spec.tsx
@@ -3,7 +3,7 @@ import { resizeHelper } from "../src/utils/pointer-interactions/resizeHelper";
 
 // High level tests; more nuanced scenarios are covered by unit tests
 test.describe("default layouts", () => {
-  test("should not cause layout shift for client components", async ({
+  test("should not cause layout shift for client components", async ({
     page
   }) => {
     await page.goto("http://localhost:3012/");
@@ -16,7 +16,7 @@ test.describe("default layouts", () => {
     await expect(page.getByText("No layout shift")).toBeVisible();
   });
 
-  test("should not cause layout shift for server-rendered client components", async ({
+  test("should not cause layout shift for server-rendered client components", async ({
     page
   }) => {
     await page.goto("http://localhost:3011/");
@@ -29,7 +29,7 @@ test.describe("default layouts", () => {
     await expect(page.getByText("No layout shift")).toBeVisible();
   });
 
-  test("should not cause layout shift for server components", async ({
+  test("should not cause layout shift for server components", async ({
     page
   }) => {
     await page.goto("http://localhost:3010/");

--- a/integrations/vike/pages/index/+Page.tsx
+++ b/integrations/vike/pages/index/+Page.tsx
@@ -73,11 +73,12 @@ export default function Page() {
       <DefaultSize defaultSize="100px" />
       <DefaultSize defaultSize="25vw" />
       <DefaultSize defaultSize="15rem" />
+      <DefaultSize defaultSize={0} />
     </div>
   );
 }
 
-function DefaultSize({ defaultSize }: { defaultSize: string }) {
+function DefaultSize({ defaultSize }: { defaultSize: number | string }) {
   return (
     <Group className="h-25 gap-2">
       <Panel className="bg-slate-800 rounded rounded-md p-2" id="left">

--- a/integrations/vite/src/routes/Home.tsx
+++ b/integrations/vite/src/routes/Home.tsx
@@ -68,11 +68,12 @@ export function HomeRoute() {
       <DefaultSize defaultSize="100px" />
       <DefaultSize defaultSize="25vw" />
       <DefaultSize defaultSize="15rem" />
+      <DefaultSize defaultSize={0} />
     </div>
   );
 }
 
-function DefaultSize({ defaultSize }: { defaultSize: string }) {
+function DefaultSize({ defaultSize }: { defaultSize: number | string }) {
   return (
     <Group className="h-25 gap-2">
       <Panel className="bg-slate-800 rounded rounded-md p-2" id="left">

--- a/lib/components/panel/Panel.tsx
+++ b/lib/components/panel/Panel.tsx
@@ -155,7 +155,7 @@ export function Panel({
   let panelStyles: CSSProperties;
   if (panelStylesString) {
     panelStyles = JSON.parse(panelStylesString);
-  } else if (defaultSize) {
+  } else if (defaultSize !== undefined) {
     panelStyles = {
       flexGrow: undefined,
       flexShrink: undefined,


### PR DESCRIPTION
When setting `defaultSize` explicitly to 0 (hidden), the layout for other panels breaks. This is due to the following code:
```typescript
// When `defaultSize` is explicitly 0, this falls through to the `flexGrow` condition, causing
// the initial render calculations to be incorrect. This can be solved by explicitly checking
// `defaultSize !== undefined`
} else if (defaultSize) {
    panelStyles = {
      flexGrow: undefined,
      flexShrink: undefined,
      flexBasis: defaultSize
    };
} else {
    panelStyles = { flexGrow: 1 };
}
```

Example case: https://codesandbox.io/p/sandbox/99tvsj