### PR TITLE
Bug fix: Calculate rem-based sizes relative to owner document (not body)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# 4.11.1
+## Unreleased
+
+- [719)](https://github.com/bvaughn/react-resizable-panels/pull/719): Bug fix: Calculate rem-based sizes relative to owner document (not body)
+
+## 4.11.1
 
 - [715)](https://github.com/bvaughn/react-resizable-panels/pull/715): Edge case SSR bug fix for panels with `defaultSize={0}`
 

--- a/lib/global/styles/convertRemToPixels.ts
+++ b/lib/global/styles/convertRemToPixels.ts
@@ -1,5 +1,5 @@
 export function convertRemToPixels(element: Element, value: number) {
-  const style = getComputedStyle(element.ownerDocument.body);
+  const style = getComputedStyle(element.ownerDocument.documentElement);
   const fontSize = parseFloat(style.fontSize);
 
   return value * fontSize;

--- a/lib/global/styles/sizeStyleToPixels.test.ts
+++ b/lib/global/styles/sizeStyleToPixels.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { setDefaultElementStyle } from "../../utils/test/mockGetComputedStyle";
+import {
+  setDefaultElementStyle,
+  setElementStyle
+} from "../../utils/test/mockGetComputedStyle";
 import { sizeStyleToPixels } from "./sizeStyleToPixels";
 
 describe("sizeStyleToPixels", () => {
@@ -117,7 +120,10 @@ describe("sizeStyleToPixels", () => {
     });
 
     test("rem units", () => {
-      setDefaultElementStyle({
+      setElementStyle(document.body, {
+        fontSize: 10
+      } as unknown as CSSStyleDeclaration);
+      setElementStyle(document.documentElement, {
         fontSize: 20
       } as unknown as CSSStyleDeclaration);
 


### PR DESCRIPTION
Resolves #718