### PR TITLE
fix #723: Ending a drag with a right-click results in panels incorrectly swallowing mouse events

### DIFF
--- a/lib/components/group/Group.test.tsx
+++ b/lib/components/group/Group.test.tsx
@@ -191,6 +191,88 @@ describe("Group", () => {
       );
     });
 
+    // See github.com/bvaughn/react-resizable-panels/issues/723
+    test("should not break if right click occurs while left click is active", async () => {
+      await runTest(
+        async () => {
+          const separatorElement = document.querySelector("[data-separator]");
+          assert(separatorElement instanceof HTMLElement);
+
+          const clientX = separatorElement.offsetLeft;
+          const clientY = separatorElement.offsetHeight / 2;
+
+          expect(separatorElement.getAttribute("data-separator")).toBe(
+            "inactive"
+          );
+
+          await userEvent.pointer([
+            {
+              keys: "[MouseLeft>]",
+              coords: {
+                clientX,
+                clientY
+              }
+            },
+            {
+              coords: {
+                clientX: clientX + 10,
+                clientY
+              }
+            }
+          ]);
+
+          expect(separatorElement.getAttribute("data-separator")).toBe(
+            "active"
+          );
+
+          await userEvent.pointer([
+            {
+              keys: "[MouseRight>]",
+              coords: {
+                clientX,
+                clientY
+              }
+            },
+            {
+              keys: "[/MouseRight]",
+              coords: {
+                clientX,
+                clientY
+              }
+            }
+          ]);
+
+          expect(separatorElement.getAttribute("data-separator")).toBe(
+            "inactive"
+          );
+
+          // No-op
+          await userEvent.pointer([
+            {
+              coords: {
+                clientX,
+                clientY
+              }
+            },
+            {
+              keys: "[/MouseLeft]",
+              coords: {
+                clientX: clientX + 10,
+                clientY
+              }
+            }
+          ]);
+
+          // TODO Verify drag state no longer active
+        },
+        {
+          left: 60,
+          right: 40
+        },
+        true
+      );
+    });
+
     test("should update when resized via keyboard", async () => {
       await runTest(
         async ({ container }) => {

--- a/lib/global/event-handlers/onDocumentContextMenu.ts
+++ b/lib/global/event-handlers/onDocumentContextMenu.ts
@@ -1,9 +1,9 @@
-import { completeResize } from "../utils/completeResize.ts";
+import { completeActivePointerResize } from "../utils/completeActivePointerResize.ts";
 
 export function onDocumentContextMenu(event: MouseEvent) {
   if (event.defaultPrevented) {
     return;
   }
 
-  completeResize(event, false);
+  completeActivePointerResize(event.currentTarget as Document);
 }

--- a/lib/global/event-handlers/onDocumentContextMenu.ts
+++ b/lib/global/event-handlers/onDocumentContextMenu.ts
@@ -1,0 +1,9 @@
+import { completeResize } from "../utils/completeResize.ts";
+
+export function onDocumentContextMenu(event: MouseEvent) {
+  if (event.defaultPrevented) {
+    return;
+  }
+
+  completeResize(event, false);
+}

--- a/lib/global/event-handlers/onDocumentPointerUp.ts
+++ b/lib/global/event-handlers/onDocumentPointerUp.ts
@@ -1,4 +1,4 @@
-import { completeResize } from "../utils/completeResize.ts";
+import { completeActivePointerResize } from "../utils/completeActivePointerResize.ts";
 
 export function onDocumentPointerUp(event: PointerEvent) {
   if (event.defaultPrevented) {
@@ -7,5 +7,8 @@ export function onDocumentPointerUp(event: PointerEvent) {
     return;
   }
 
-  completeResize(event, true);
+  const matched = completeActivePointerResize(event.currentTarget as Document);
+  if (matched) {
+    event.preventDefault();
+  }
 }

--- a/lib/global/event-handlers/onDocumentPointerUp.ts
+++ b/lib/global/event-handlers/onDocumentPointerUp.ts
@@ -1,12 +1,4 @@
-import { updateCursorStyle } from "../cursor/updateCursorStyle";
-import {
-  getMountedGroupState,
-  updateMountedGroup
-} from "../mutable-state/groups";
-import {
-  getInteractionState,
-  updateInteractionState
-} from "../mutable-state/interactions";
+import { completeResize } from "../utils/completeResize.ts";
 
 export function onDocumentPointerUp(event: PointerEvent) {
   if (event.defaultPrevented) {
@@ -15,31 +7,5 @@ export function onDocumentPointerUp(event: PointerEvent) {
     return;
   }
 
-  const interactionState = getInteractionState();
-
-  switch (interactionState.state) {
-    case "active": {
-      updateInteractionState({
-        cursorFlags: 0,
-        state: "inactive"
-      });
-
-      if (interactionState.hitRegions.length > 0) {
-        updateCursorStyle(event.currentTarget as Document);
-
-        // Dispatch one more "change" event after the interaction state has been reset.
-        // Groups use this as a signal to call onLayoutChanged.
-        // This is the canonical user-pointer-up site, so flag the dispatch with
-        // isUserInteraction: true. See #716.
-        interactionState.hitRegions.forEach((hitRegion) => {
-          const groupState = getMountedGroupState(hitRegion.group.id, true);
-          updateMountedGroup(hitRegion.group, groupState, {
-            isUserInteraction: true
-          });
-        });
-
-        event.preventDefault();
-      }
-    }
-  }
+  completeResize(event, true);
 }

--- a/lib/global/mountGroup.ts
+++ b/lib/global/mountGroup.ts
@@ -3,6 +3,7 @@ import { assert } from "../utils/assert";
 import { calculateAvailableGroupSize } from "./dom/calculateAvailableGroupSize";
 import { calculateHitRegions } from "./dom/calculateHitRegions";
 import { calculatePanelConstraints } from "./dom/calculatePanelConstraints";
+import { onDocumentContextMenu } from "./event-handlers/onDocumentContextMenu";
 import { onDocumentDoubleClick } from "./event-handlers/onDocumentDoubleClick";
 import { onDocumentKeyDown } from "./event-handlers/onDocumentKeyDown";
 import { onDocumentPointerDown } from "./event-handlers/onDocumentPointerDown";
@@ -179,6 +180,7 @@ export function mountGroup(group: RegisteredGroup) {
 
   // If this is the first group to be mounted, initialize event handlers
   if (ownerDocumentReferenceCounts.get(ownerDocument) === 1) {
+    ownerDocument.addEventListener("contextmenu", onDocumentContextMenu, true);
     ownerDocument.addEventListener("dblclick", onDocumentDoubleClick, true);
     ownerDocument.addEventListener("pointerdown", onDocumentPointerDown, true);
     ownerDocument.addEventListener("pointerleave", onDocumentPointerLeave);
@@ -203,6 +205,11 @@ export function mountGroup(group: RegisteredGroup) {
 
     // If this was the last group to be mounted, tear down event handlers
     if (!ownerDocumentReferenceCounts.get(ownerDocument)) {
+      ownerDocument.removeEventListener(
+        "contextmenu",
+        onDocumentContextMenu,
+        true
+      );
       ownerDocument.removeEventListener(
         "dblclick",
         onDocumentDoubleClick,

--- a/lib/global/utils/completeActivePointerResize.ts
+++ b/lib/global/utils/completeActivePointerResize.ts
@@ -8,8 +8,10 @@ import {
   updateInteractionState
 } from "../mutable-state/interactions.ts";
 
-export function completeResize(event: MouseEvent, preventDefault: boolean) {
+export function completeActivePointerResize(document: Document) {
   const interactionState = getInteractionState();
+
+  let match = false;
 
   switch (interactionState.state) {
     case "active": {
@@ -19,7 +21,9 @@ export function completeResize(event: MouseEvent, preventDefault: boolean) {
       });
 
       if (interactionState.hitRegions.length > 0) {
-        updateCursorStyle(event.currentTarget as Document);
+        updateCursorStyle(document);
+
+        match = true;
 
         // Dispatch one more "change" event after the interaction state has been reset.
         // Groups use this as a signal to call onLayoutChanged.
@@ -31,11 +35,9 @@ export function completeResize(event: MouseEvent, preventDefault: boolean) {
             isUserInteraction: true
           });
         });
-
-        if (preventDefault) {
-          event.preventDefault();
-        }
       }
     }
   }
+
+  return match;
 }

--- a/lib/global/utils/completeResize.ts
+++ b/lib/global/utils/completeResize.ts
@@ -1,0 +1,41 @@
+import { updateCursorStyle } from "../cursor/updateCursorStyle.ts";
+import {
+  getMountedGroupState,
+  updateMountedGroup
+} from "../mutable-state/groups.ts";
+import {
+  getInteractionState,
+  updateInteractionState
+} from "../mutable-state/interactions.ts";
+
+export function completeResize(event: MouseEvent, preventDefault: boolean) {
+  const interactionState = getInteractionState();
+
+  switch (interactionState.state) {
+    case "active": {
+      updateInteractionState({
+        cursorFlags: 0,
+        state: "inactive"
+      });
+
+      if (interactionState.hitRegions.length > 0) {
+        updateCursorStyle(event.currentTarget as Document);
+
+        // Dispatch one more "change" event after the interaction state has been reset.
+        // Groups use this as a signal to call onLayoutChanged.
+        // This is the canonical user-pointer-up site, so flag the dispatch with
+        // isUserInteraction: true. See #716.
+        interactionState.hitRegions.forEach((hitRegion) => {
+          const groupState = getMountedGroupState(hitRegion.group.id, true);
+          updateMountedGroup(hitRegion.group, groupState, {
+            isUserInteraction: true
+          });
+        });
+
+        if (preventDefault) {
+          event.preventDefault();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The new file `completeResize.ts` simply relocates the implementation that was previously in `onDocumentPointerUp.ts`, except for one difference: `event.preventDefault()` is now wrapped in an `if`.

onDocumentPointerUp prevents the default, and onDocumentContextMenu does not. This is so the context menu will still appear.

There are no new tests for this, sorry. I did try to write one but it was passing with or without the bugfix, so the test is pointless. The problem seems to be that Playwright doesn't support context menus. In Playwright, the right-click effectively gets ignored, so it doesn't break the interaction in the same way it does for Chrome. I tried some hacks to get it to work, like listening for contextmenu events on the document, but I couldn't find a way around it.

All existing tests are still passing and I manually confirmed the fix in the browser:

https://github.com/user-attachments/assets/80c2f158-d950-48af-8e4f-4c304d84e916

<details>
<summary>broken attempt at playwright test</summary>

```typescript
  // See github.com/bvaughn/react-resizable-panels/issues/723
  test("should restore pointer-events after a resize is interrupted by right-click", async ({
    page: mainPage
  }) => {
    const page = await goToUrl(
      mainPage,
      <Group>
        <Panel id="left">
          <Clickable />
        </Panel>
        <Separator id="separator" />
        <Panel id="right" />
      </Group>
    );

    const separator = page.getByTestId("separator");
    const separatorBox = await separator.boundingBox();
    if (!separatorBox) throw new Error("Separator has no bounding box");
    const { x, y } = getCenterCoordinates(separatorBox);

    const clickable = page.getByText("Clickable");
    await clickable.click();
    await expect(clickable).toContainText("click:1");

    await page.mouse.move(x, y); // go to separator
    await page.mouse.down(); // press and hold left click

    await page.mouse.click(x + 20, y, { button: "right" });

    // press and release right click (left click is still down)
    await page.mouse.down({ button: "right" });
    await page.mouse.up({ button: "right" });

    await page.mouse.up(); // release left click
    await page.mouse.click(0, 0); // dismiss the context menu

    const leftPanel = page.getByTestId("left");
    await expect(leftPanel).toHaveCSS("pointer-events", "auto");
    await clickable.click();
    await expect(clickable).toContainText("click:2");
  });
  ```
  </details>