### PR TITLE
fix: guard CSSStyleSheet construction with adoptedStyleSheets check

### DIFF
--- a/lib/global/cursor/updateCursorStyle.test.ts
+++ b/lib/global/cursor/updateCursorStyle.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { updateInteractionState } from "../mutable-state/interactions";
+import { updateCursorStyle } from "./updateCursorStyle";
+
+describe("updateCursorStyle", () => {
+  const originalCSSStyleSheet = window.CSSStyleSheet;
+  const originalAdoptedStyleSheets = Object.getOwnPropertyDescriptor(
+    Document.prototype,
+    "adoptedStyleSheets"
+  );
+
+  afterEach(() => {
+    // Restore global mocks
+    window.CSSStyleSheet = originalCSSStyleSheet;
+    if (originalAdoptedStyleSheets) {
+      Object.defineProperty(
+        Document.prototype,
+        "adoptedStyleSheets",
+        originalAdoptedStyleSheets
+      );
+    }
+    updateInteractionState({
+      cursorFlags: 0,
+      state: "inactive"
+    });
+  });
+
+  test("should not throw if the environment doesn't support constructable stylesheets", () => {
+    // e.g. Safari < 16.4. Calling `new CSSStyleSheet()` throws
+    // "TypeError: Illegal constructor" in those browsers.
+    window.CSSStyleSheet = class CSSStyleSheet {
+      constructor() {
+        throw new TypeError("Illegal constructor");
+      }
+    };
+    Object.defineProperty(Document.prototype, "adoptedStyleSheets", {
+      configurable: true,
+      get() {
+        return undefined;
+      }
+    });
+
+    updateInteractionState({
+      cursorFlags: 0,
+      state: "hover",
+      hitRegions: []
+    });
+
+    expect(() => updateCursorStyle(document)).not.toThrow();
+  });
+
+  test("should apply cursor styles when constructable stylesheets are supported", () => {
+    const styleSheet = new CSSStyleSheet();
+    Object.defineProperty(Document.prototype, "adoptedStyleSheets", {
+      configurable: true,
+      value: [styleSheet]
+    });
+
+    updateInteractionState({
+      cursorFlags: 0,
+      state: "hover",
+      hitRegions: []
+    });
+
+    updateCursorStyle(document);
+
+    expect(document.adoptedStyleSheets).toContain(styleSheet);
+  });
+});

--- a/lib/global/cursor/updateCursorStyle.test.ts
+++ b/lib/global/cursor/updateCursorStyle.test.ts
@@ -28,6 +28,7 @@ describe("updateCursorStyle", () => {
   test("should not throw if the environment doesn't support constructable stylesheets", () => {
     // e.g. Safari < 16.4. Calling `new CSSStyleSheet()` throws
     // "TypeError: Illegal constructor" in those browsers.
+    // @ts-expect-error Testing
     window.CSSStyleSheet = class CSSStyleSheet {
       constructor() {
         throw new TypeError("Illegal constructor");

--- a/lib/global/cursor/updateCursorStyle.ts
+++ b/lib/global/cursor/updateCursorStyle.ts
@@ -10,25 +10,19 @@ const documentToStyleMap = new WeakMap<
 >();
 
 export function updateCursorStyle(ownerDocument: Document) {
-  // NOTE undefined is not technically a valid value but it has been reported that it is present in some environments (Vite HMR?)
-  // See github.com/bvaughn/react-resizable-panels/issues/559
-  if (
-    ownerDocument.defaultView === null ||
-    ownerDocument.defaultView === undefined
-  ) {
+  if (!ownerDocument.defaultView || !ownerDocument.adoptedStyleSheets) {
+    // Gracefully degrade for environments that don't support these DOM APIs (e.g. Safari < 16.4, jsdom)
+    // See issues#559, issues#621, issues#554, pull#730
     return;
   }
 
   let { prevStyle, styleSheet } = documentToStyleMap.get(ownerDocument) ?? {};
 
   if (styleSheet === undefined) {
-    // Constructable stylesheets aren't supported in all environments
-    // (e.g. Safari < 16.4, jsdom). Calling `new CSSStyleSheet()` there
-    // throws "TypeError: Illegal constructor", so only construct one when
-    // adoptedStyleSheets is available.
-    if (ownerDocument.adoptedStyleSheets) {
-      styleSheet = new ownerDocument.defaultView.CSSStyleSheet();
+    styleSheet = new ownerDocument.defaultView.CSSStyleSheet();
 
+    // adoptedStyleSheets is undefined in jsdom
+    if (ownerDocument.adoptedStyleSheets) {
       if (Object.isExtensible(ownerDocument.adoptedStyleSheets)) {
         ownerDocument.adoptedStyleSheets.push(styleSheet);
       } else {
@@ -38,12 +32,6 @@ export function updateCursorStyle(ownerDocument: Document) {
         ];
       }
     }
-  }
-
-  if (styleSheet === undefined) {
-    // The environment doesn't support constructed stylesheets, so cursor
-    // overrides can't be applied. This is a no-op, not an error.
-    return;
   }
 
   const interactionState = getInteractionState();

--- a/lib/global/cursor/updateCursorStyle.ts
+++ b/lib/global/cursor/updateCursorStyle.ts
@@ -22,10 +22,13 @@ export function updateCursorStyle(ownerDocument: Document) {
   let { prevStyle, styleSheet } = documentToStyleMap.get(ownerDocument) ?? {};
 
   if (styleSheet === undefined) {
-    styleSheet = new ownerDocument.defaultView.CSSStyleSheet();
-
-    // adoptedStyleSheets is undefined in jsdom
+    // Constructable stylesheets aren't supported in all environments
+    // (e.g. Safari < 16.4, jsdom). Calling `new CSSStyleSheet()` there
+    // throws "TypeError: Illegal constructor", so only construct one when
+    // adoptedStyleSheets is available.
     if (ownerDocument.adoptedStyleSheets) {
+      styleSheet = new ownerDocument.defaultView.CSSStyleSheet();
+
       if (Object.isExtensible(ownerDocument.adoptedStyleSheets)) {
         ownerDocument.adoptedStyleSheets.push(styleSheet);
       } else {
@@ -35,6 +38,12 @@ export function updateCursorStyle(ownerDocument: Document) {
         ];
       }
     }
+  }
+
+  if (styleSheet === undefined) {
+    // The environment doesn't support constructed stylesheets, so cursor
+    // overrides can't be applied. This is a no-op, not an error.
+    return;
   }
 
   const interactionState = getInteractionState();


### PR DESCRIPTION
## Summary

`updateCursorStyle` unconditionally calls `new CSSStyleSheet()` and only checks `adoptedStyleSheets` afterwards (inside a separate `if`). Constructable Stylesheets are not supported in all environments — e.g. **Safari < 16.4** — where calling the constructor throws `TypeError: Illegal constructor`. The check after construction could never protect those browsers, so every `pointermove` over a resizable panel throws an unhandled error there (269 events / 31 users on production at kalodata.com).

## Fix

- Move the `new CSSStyleSheet()` construction **inside** the `adoptedStyleSheets` feature check.
- Bail out early when no stylesheet could be created — cursor overrides are skipped in unsupported environments instead of throwing.
- No behavior change for browsers that support constructable stylesheets (Chrome, Firefox, Safari 16.4+, Edge).

## Testing

Added a regression test that mocks an environment where `CSSStyleSheet` is not constructable (mirroring Safari 16.1) and verifies `updateCursorStyle` does not throw. Verified the test fails with `TypeError: Illegal constructor` on the old code and passes with the fix. Full suite: 428 tests passing.

## Related

- #621 (custom cursor doesn't work in Safari)
- #554 (ownerDocument/defaultView handling)