### PR TITLE
fix: don't resurrect stale group entries on pointer-up commit (Fixes #729)

### DIFF
--- a/lib/global/event-handlers/onDocumentPointerMove.ts
+++ b/lib/global/event-handlers/onDocumentPointerMove.ts
@@ -37,6 +37,11 @@ export function onDocumentPointerMove(event: PointerEvent) {
         // This is the missed-pointerup fallback (pointer released outside a
         // cross-origin iframe, see #340) — still a real user interaction.
         interactionState.hitRegions.forEach((hitRegion) => {
+          // Skip if the group was re-registered mid-gesture, so the old hit region
+          // doesn't resurrect a stale entry in the mounted-groups map. See #729.
+          if (!mountedGroups.has(hitRegion.group)) {
+            return;
+          }
           const groupState = getMountedGroupState(hitRegion.group.id, true);
           updateMountedGroup(hitRegion.group, groupState, {
             isUserInteraction: true

--- a/lib/global/utils/completeActivePointerResize.ts
+++ b/lib/global/utils/completeActivePointerResize.ts
@@ -1,5 +1,6 @@
 import { updateCursorStyle } from "../cursor/updateCursorStyle.ts";
 import {
+  getMountedGroups,
   getMountedGroupState,
   updateMountedGroup
 } from "../mutable-state/groups.ts";
@@ -30,6 +31,11 @@ export function completeActivePointerResize(document: Document) {
         // This is the canonical user-pointer-up site, so flag the dispatch with
         // isUserInteraction: true. See #716.
         interactionState.hitRegions.forEach((hitRegion) => {
+          // Skip if the group was re-registered mid-gesture, so the old hit region
+          // doesn't resurrect a stale entry in the mounted-groups map. See #729.
+          if (!getMountedGroups().has(hitRegion.group)) {
+            return;
+          }
           const groupState = getMountedGroupState(hitRegion.group.id, true);
           updateMountedGroup(hitRegion.group, groupState, {
             isUserInteraction: true

--- a/lib/global/utils/completeActivePointerResize.ts
+++ b/lib/global/utils/completeActivePointerResize.ts
@@ -11,6 +11,7 @@ import {
 
 export function completeActivePointerResize(document: Document) {
   const interactionState = getInteractionState();
+  const mountedGroups = getMountedGroups();
 
   let match = false;
 
@@ -33,7 +34,7 @@ export function completeActivePointerResize(document: Document) {
         interactionState.hitRegions.forEach((hitRegion) => {
           // Skip if the group was re-registered mid-gesture, so the old hit region
           // doesn't resurrect a stale entry in the mounted-groups map. See #729.
-          if (!getMountedGroups().has(hitRegion.group)) {
+          if (!mountedGroups.has(hitRegion.group)) {
             return;
           }
           const groupState = getMountedGroupState(hitRegion.group.id, true);


### PR DESCRIPTION
## Summary

A pointer gesture (or a queued commit) that straddles a group re-registration can re-insert an already-deleted `RegisteredGroup` object into the module-global mounted-groups map, leaving **two map entries under one group id**. After that, by-id lookups and by-object lookups resolve to different entries, and the group is permanently broken until a full remount/reload.

## Root cause

`updateMountedGroup()` unconditionally re-inserts the group object even if it was deleted by `deleteMutableGroup()`. When a group re-registers between pointerdown and the final commit dispatch, `hitRegion.group` holds the deleted object, and `updateMountedGroup(oldGroup, …)` resurrects it.

## Fix

Skip hit regions whose group registration has been replaced — the final commit belongs to a dead epoch, and the live entry already owns the current state. Applied the guard in both dispatch sites:

1. `lib/global/utils/completeActivePointerResize.ts` — canonical pointer-up dispatch
2. `lib/global/event-handlers/onDocumentPointerMove.ts` — missed-pointerup fallback (cross-origin iframe case)

## Testing

The issue reporter has been running this exact fix as a `patch-package` patch against 4.12.2 in production: the stress harness that previously wedged the handle within ≤3 rounds now runs 16+ rounds clean, with no observed regressions in drag, keyboard resize, collapse, or `onLayoutChanged`.

Fixes #729