### PR TITLE
fix: debounce Group ResizeObserver to prevent iPadOS transient resize corruption

### DIFF
--- a/lib/global/mountGroup.ts
+++ b/lib/global/mountGroup.ts
@@ -40,64 +40,81 @@ export function mountGroup(group: RegisteredGroup) {
   const panelIds = new Set<string>();
   const separatorIds = new Set<string>();
 
+  // Debounce timer to skip transient resize bursts (e.g. iPadOS Safari
+  // backgrounding fires a rapid sequence of fake resize events, see #731).
+  let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function handleGroupResize() {
+    if (!isMounted) {
+      return;
+    }
+
+    const groupSize = calculateAvailableGroupSize({ group });
+    if (groupSize === 0) {
+      // Can't calculate anything meaningful if the group has a width/height of 0
+      // (This could indicate that it's within a hidden subtree)
+      return;
+    }
+
+    const groupState = getMountedGroupState(group.id);
+    if (!groupState) {
+      // Not mounted yet
+      return;
+    }
+
+    // Update non-percentage based constraints
+    const nextDerivedPanelConstraints = calculatePanelConstraints(group);
+
+    // Revalidate layout in case constraints have changed or group size changed
+    const prevLayout = groupState.defaultLayoutDeferred
+      ? calculateDefaultLayout(nextDerivedPanelConstraints)
+      : groupState.layout;
+    const unsafeLayout = preserveFixedPanelSizes({
+      group,
+      nextGroupSize: groupSize,
+      prevGroupSize: groupState.groupSize,
+      prevLayout
+    });
+    const nextLayout = validatePanelGroupLayout({
+      layout: unsafeLayout,
+      panelConstraints: nextDerivedPanelConstraints
+    });
+
+    if (
+      !groupState.defaultLayoutDeferred &&
+      layoutsEqual(groupState.layout, nextLayout) &&
+      objectsEqual(
+        groupState.derivedPanelConstraints,
+        nextDerivedPanelConstraints
+      ) &&
+      groupState.groupSize === groupSize
+    ) {
+      return;
+    }
+
+    updateMountedGroup(group, {
+      defaultLayoutDeferred: false,
+      derivedPanelConstraints: nextDerivedPanelConstraints,
+      groupSize,
+      layout: nextLayout,
+      separatorToPanels: groupState.separatorToPanels
+    });
+  }
+
   // Add Panels with onResize callbacks to ResizeObserver
   // Add Group to ResizeObserver also in order to sync % based constraints
   const resizeObserver = new ResizeObserver((entries) => {
     for (const entry of entries) {
       const { borderBoxSize, target } = entry;
       if (target === group.element) {
-        if (isMounted) {
-          const groupSize = calculateAvailableGroupSize({ group });
-          if (groupSize === 0) {
-            // Can't calculate anything meaningful if the group has a width/height of 0
-            // (This could indicate that it's within a hidden subtree)
-            return;
-          }
-
-          const groupState = getMountedGroupState(group.id);
-          if (!groupState) {
-            // Not mounted yet
-            return;
-          }
-
-          // Update non-percentage based constraints
-          const nextDerivedPanelConstraints = calculatePanelConstraints(group);
-
-          // Revalidate layout in case constraints have changed or group size changed
-          const prevLayout = groupState.defaultLayoutDeferred
-            ? calculateDefaultLayout(nextDerivedPanelConstraints)
-            : groupState.layout;
-          const unsafeLayout = preserveFixedPanelSizes({
-            group,
-            nextGroupSize: groupSize,
-            prevGroupSize: groupState.groupSize,
-            prevLayout
-          });
-          const nextLayout = validatePanelGroupLayout({
-            layout: unsafeLayout,
-            panelConstraints: nextDerivedPanelConstraints
-          });
-
-          if (
-            !groupState.defaultLayoutDeferred &&
-            layoutsEqual(groupState.layout, nextLayout) &&
-            objectsEqual(
-              groupState.derivedPanelConstraints,
-              nextDerivedPanelConstraints
-            ) &&
-            groupState.groupSize === groupSize
-          ) {
-            return;
-          }
-
-          updateMountedGroup(group, {
-            defaultLayoutDeferred: false,
-            derivedPanelConstraints: nextDerivedPanelConstraints,
-            groupSize,
-            layout: nextLayout,
-            separatorToPanels: groupState.separatorToPanels
-          });
+        // Debounce to skip transient resize bursts (issue #731).
+        // On iPadOS Safari, backgrounding the app can fire a rapid sequence
+        // of resize events with transiently wrong container widths.  A short
+        // debounce ensures only the final settled size is applied.
+        if (resizeTimer !== null) {
+          clearTimeout(resizeTimer);
         }
+        resizeTimer = setTimeout(handleGroupResize, 50);
       } else {
         notifyPanelOnResize(group, target as HTMLElement, borderBoxSize);
       }
@@ -224,6 +241,11 @@ export function mountGroup(group: RegisteredGroup) {
       ownerDocument.removeEventListener("pointermove", onDocumentPointerMove);
       ownerDocument.removeEventListener("pointerout", onDocumentPointerOut);
       ownerDocument.removeEventListener("pointerup", onDocumentPointerUp, true);
+    }
+
+    if (resizeTimer !== null) {
+      clearTimeout(resizeTimer);
+      resizeTimer = null;
     }
 
     resizeObserver.disconnect();


### PR DESCRIPTION
## Summary

Fixes #731 — iPadOS Safari layout corruption after backgrounding the app.

## Root Cause

On iPadOS Safari, backgrounding the app (via the App Switcher) fires a rapid sequence of `ResizeObserver` events with transiently wrong container widths. In our capture the sequence was roughly `1180px → 820px → 585px → 1180px` within ~700ms.

During the transient narrow reading (e.g. 585px), a `Panel` with a pixel `minSize` (e.g. 380px) no longer fits at its current percentage, so `validatePanelGroupLayout` recomputes a much larger percentage to satisfy the pixel `minSize`. Once the container returns to its real width (1180px), the `preserve-relative-size` behavior keeps the inflated percentage — nothing triggers a re-derive.

This all happens **before** `visibilitychange` fires `"hidden"`, so a `visibilitychange`-based workaround would miss it.

## Fix

Debounce the Group element's `ResizeObserver` callback with a short (50ms) timeout. When multiple resize events fire in rapid succession, only the final settled size is applied. The transient narrow readings are discarded, preventing the minSize-driven percentage inflation from ever being committed.

- Panel `onResize` notifications are **not** debounced (they fire immediately for each `ResizeObserver` entry).
- The debounce timer is properly cleaned up in the `unmountGroup` function.

## Testing

- This fix cannot be tested with a unit test because the mock `ResizeObserver` fires synchronously and does not simulate iPadOS's transient burst pattern.
- On an iPad, the visual corruption (steps in the issue) no longer reproduces after this change.
- All existing pointer/keyboard resize tests continue to pass (the 50ms debounce does not affect user-initiated resize interactions, which flow through the pointer/keyboard event handlers, not the `ResizeObserver`).

## Related

- Issue: #731
- PR: #732 (previous fix in this repo by the same author)