### PR TITLE
fix: use group-relative panel index for Separator aria values (Fixes #740)

### DIFF
--- a/lib/components/separator/Separator.test.tsx
+++ b/lib/components/separator/Separator.test.tsx
@@ -139,6 +139,18 @@ describe("Separator", () => {
     });
 
     describe("ARIA attributes", () => {
+      function printSeparators() {
+        return screen
+          .getAllByRole("separator")
+          .map(
+            (separator) => `${separator.id}
+  controls: ${separator.getAttribute("aria-controls")}
+  value: ${separator.getAttribute("aria-valuenow")}% (${separator.getAttribute("aria-valuemin")}% - ${separator.getAttribute("aria-valuemax")}%)
+`
+          )
+          .join("\n");
+      }
+
       test("should identify its primary panel if and only if it has an explicit id", () => {
         render(
           <Group>
@@ -170,28 +182,33 @@ describe("Separator", () => {
           </Group>
         );
 
-        // Every Separator's aria-valuenow should fall within its advertised
-        // aria-valuemin/aria-valuemax range; see #740
-        expect(
-          screen
-            .getAllByRole("separator")
-            .map((separator) =>
-              (
-                [
-                  "aria-controls",
-                  "aria-valuemin",
-                  "aria-valuenow",
-                  "aria-valuemax"
-                ] as const
-              )
-                .map((name) => `${name}=${separator.getAttribute(name)}`)
-                .join(" ")
-            )
-        ).toMatchInlineSnapshot(`
-          [
-            "aria-controls=left-panel aria-valuemin=0 aria-valuenow=33.334 aria-valuemax=100",
-            "aria-controls=middle-panel aria-valuemin=0 aria-valuenow=33.333 aria-valuemax=66.666",
-          ]
+        expect(printSeparators()).toMatchInlineSnapshot(`
+          "left-separator
+            controls: left-panel
+            value: 33.334% (0% - 100%)
+
+          right-separator
+            controls: middle-panel
+            value: 33.333% (0% - 66.666%)
+          "
+        `);
+      });
+
+      test("should blah", () => {
+        render(
+          <Group>
+            <Panel id="left-panel" />
+            <Panel id="middle-panel" />
+            <Separator id="only-separator" />
+            <Panel id="right-panel" />
+          </Group>
+        );
+
+        expect(printSeparators()).toMatchInlineSnapshot(`
+          "only-separator
+            controls: middle-panel
+            value: 33.333% (0% - 66.666%)
+          "
         `);
       });
     });

--- a/lib/components/separator/Separator.test.tsx
+++ b/lib/components/separator/Separator.test.tsx
@@ -158,6 +158,42 @@ describe("Separator", () => {
           "aria-controls"
         );
       });
+
+      test("should compute values relative to the Group (not the Separator's own panel pair)", () => {
+        render(
+          <Group>
+            <Panel id="left-panel" />
+            <Separator id="left-separator" />
+            <Panel id="middle-panel" />
+            <Separator id="right-separator" />
+            <Panel id="right-panel" />
+          </Group>
+        );
+
+        // Every Separator's aria-valuenow should fall within its advertised
+        // aria-valuemin/aria-valuemax range; see #740
+        expect(
+          screen
+            .getAllByRole("separator")
+            .map((separator) =>
+              (
+                [
+                  "aria-controls",
+                  "aria-valuemin",
+                  "aria-valuenow",
+                  "aria-valuemax"
+                ] as const
+              )
+                .map((name) => `${name}=${separator.getAttribute(name)}`)
+                .join(" ")
+            )
+        ).toMatchInlineSnapshot(`
+          [
+            "aria-controls=left-panel aria-valuemin=0 aria-valuenow=33.334 aria-valuemax=100",
+            "aria-controls=middle-panel aria-valuemin=0 aria-valuenow=33.333 aria-valuemax=66.666",
+          ]
+        `);
+      });
     });
   });
 });

--- a/lib/components/separator/Separator.tsx
+++ b/lib/components/separator/Separator.tsx
@@ -106,7 +106,14 @@ export function Separator({
           const panels = separatorToPanels.get(separator);
           if (panels) {
             const primaryPanel = panels[0];
-            const panelIndex = panels.indexOf(primaryPanel);
+
+            // The index must be relative to the Group's panels (not the pair
+            // this Separator sits between) because it's used as a pivot index
+            // into the Group's layout. derivedPanelConstraints is derived from
+            // group.panels, so it's already in panel order. See #740.
+            const panelIndex = derivedPanelConstraints.findIndex(
+              (constraints) => constraints.panelId === primaryPanel.id
+            );
 
             setAria(
               calculateSeparatorAriaValues({

--- a/lib/components/separator/Separator.tsx
+++ b/lib/components/separator/Separator.tsx
@@ -107,10 +107,10 @@ export function Separator({
           if (panels) {
             const primaryPanel = panels[0];
 
-            // The index must be relative to the Group's panels (not the pair
-            // this Separator sits between) because it's used as a pivot index
-            // into the Group's layout. derivedPanelConstraints is derived from
-            // group.panels, so it's already in panel order. See #740.
+            // The index must be relative to the Group's panels (not the pair this Separator sits between
+            // because it's used as a pivot index into the Group's layout.
+            // derivedPanelConstraints is derived from group.panels, so it's already in panel order.
+            // See #740.
             const panelIndex = derivedPanelConstraints.findIndex(
               (constraints) => constraints.panelId === primaryPanel.id
             );


### PR DESCRIPTION
Fixes #740.

### Where to look

`Separator` computed `panelIndex` from the `[primaryPanel, secondaryPanel]` tuple it
gets out of `separatorToPanels`:

```ts
const primaryPanel = panels[0];
const panelIndex = panels.indexOf(primaryPanel); // always 0
```

`calculateSeparatorAriaValues` then uses that as a **group-relative** pivot index
(`pivotIndices = [panelIndex, panelIndex + 1]`) into the group's layout, so every
separator probed the boundary between panels 0 and 1. That happens to be correct for
the first separator, which is why two-panel groups — every existing fixture — never
saw it. In a group of three or more, the later separators reported `aria-valuemin`
and `aria-valuemax` swapped, putting `aria-valuenow` outside the advertised range.

The fix looks the index up in `derivedPanelConstraints`, which `calculatePanelConstraints`
builds as `group.panels.map(...)`, so it is already in panel order and already in scope
in that subscriber.

### Risk

`derivedPanelConstraints` and `separatorToPanels` come from the same
`subscribeToMountedGroup` event, so they are always the same snapshot of the group —
the lookup cannot see a stale panel list. If a panel id were somehow absent,
`findIndex` returns `-1`, but `calculateSeparatorAriaValues` bails out first on its own
`panelConstraints.find(...)` miss against the same array, so it can't reach
`adjustLayoutByDelta` with a negative index.

Behavior for two-panel groups is unchanged (index 0 either way), which is why the
existing unit and e2e aria assertions are untouched.

### Test

Added a regression test in `Separator.test.tsx` for a three-panel group. Before the
fix it produced:

```
aria-controls=middle-panel aria-valuemin=66.666 aria-valuenow=33.333 aria-valuemax=0
```

and after:

```
aria-controls=middle-panel aria-valuemin=0 aria-valuenow=33.333 aria-valuemax=66.666
```

### Checks run locally

`vitest run` (438 tests), `tsc -b`, `eslint`, `prettier --check`, `vite build` for the
lib target — all clean. `compile-docs` and `compile-examples` produce no diff.
I did not run the Playwright suite; the e2e aria assertions in
`keyboard-interactions.spec.tsx` are all two-panel groups, which this change leaves
untouched.

I left `CHANGELOG.md` alone, following #732 and #736.
