### PR TITLE
fix: skip pointer capture for detached separators

### DIFF
--- a/integrations/tests/src/components/DisplayModeToggle.tsx
+++ b/integrations/tests/src/components/DisplayModeToggle.tsx
@@ -7,7 +7,7 @@ import {
 
 export type DisplayModeToggleProps = PropsWithChildren<{
   defaultVisible?: boolean;
-  mode: "activity" | "css";
+  mode: "activity" | "conditional" | "css";
 }>;
 
 export function DisplayModeToggle({
@@ -37,6 +37,10 @@ export function DisplayModeToggle({
           {childrenProp}
         </div>
       );
+      break;
+    }
+    case "conditional": {
+      children = visible ? childrenProp : null;
       break;
     }
   }

--- a/integrations/tests/tests/pointer-interactions.spec.tsx
+++ b/integrations/tests/tests/pointer-interactions.spec.tsx
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { Clickable } from "../src/components/Clickable";
 import { Container } from "../src/components/Container";
+import { DisplayModeToggle } from "../src/components/DisplayModeToggle";
 import { IFrame } from "../src/components/IFrame";
 import { assertLayoutChangeCounts } from "../src/utils/assertLayoutChangeCounts";
 import { calculateHitArea } from "../src/utils/calculateHitArea";
@@ -597,6 +598,50 @@ test.describe("pointer interactions", () => {
     await page.mouse.move(0, 0);
     await page.mouse.down();
     await expect(separator).toHaveAttribute("data-separator", "inactive");
+  });
+
+  test("should ignore pointer capture for a group unmounted during a drag", async ({
+    page: mainPage
+  }) => {
+    const page = await goToUrl(
+      mainPage,
+      <Container className="flex flex-col gap-4">
+        <DisplayModeToggle defaultVisible mode="conditional">
+          <Group>
+            <Panel id="left" />
+            <Separator id="unmounted-separator" />
+            <Panel id="right" />
+          </Group>
+        </DisplayModeToggle>
+        <Group>
+          <Panel id="persistent-left" />
+          <Separator />
+          <Panel id="persistent-right" />
+        </Group>
+      </Container>
+    );
+    const errors: Error[] = [];
+    page.on("pageerror", (error) => errors.push(error));
+
+    const separator = page.getByTestId("unmounted-separator");
+    const { x, y } = getCenterCoordinates((await separator.boundingBox())!);
+
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x - 25, y);
+    await expect(separator).toHaveAttribute("data-separator", "active");
+
+    await page
+      .getByRole("button")
+      .evaluate((button) =>
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      );
+    await expect(separator).toHaveCount(0);
+
+    await page.mouse.move(x - 50, y);
+    await page.mouse.up();
+
+    expect(errors).toEqual([]);
   });
 
   test("should not prevent click events if no drag occurs", async ({

--- a/lib/global/event-handlers/onDocumentPointerMove.ts
+++ b/lib/global/event-handlers/onDocumentPointerMove.ts
@@ -54,7 +54,10 @@ export function onDocumentPointerMove(event: PointerEvent) {
       for (const hitRegion of interactionState.hitRegions) {
         if (hitRegion.separator) {
           const { element } = hitRegion.separator;
-          if (!element.hasPointerCapture?.(event.pointerId)) {
+          if (
+            element.isConnected &&
+            !element.hasPointerCapture?.(event.pointerId)
+          ) {
             element.setPointerCapture?.(event.pointerId);
           }
         }


### PR DESCRIPTION
Hi 👋🏼 

## Summary

A separator can be unmounted during an active drag while document listeners remain mounted for another panel group. The frozen drag hit regions then retain the detached separator, and the next pointer move calls `setPointerCapture` on it, which throws an `InvalidStateError`. This isn't a big issue, but it does create a lot of noise in Sentry.

The changes require the separator to be connected before capturing the pointer. This preserves the existing capture path and skips only elements the browser cannot capture.

The regression extends the test-only `DisplayModeToggle` with a `conditional` mode because its existing `activity` and `css` modes keep children mounted. The new mode renders `null`, reproducing the actual separator unmount without changing the library's public API.

Before: `pointermove` -> frozen hit region -> detached separator -> `setPointerCapture` throws

After: `pointermove` -> frozen hit region -> detached separator is skipped
