### PR TITLE
Stop disabling pointer-events on panels during resize

### DIFF
--- a/integrations/tests/tests/pointer-interactions.spec.tsx
+++ b/integrations/tests/tests/pointer-interactions.spec.tsx
@@ -276,36 +276,6 @@ test.describe("pointer interactions", () => {
     await expect(mainPage.getByText('"left": 95')).toBeVisible();
   });
 
-  test("should disable pointer-events while resize is active", async ({
-    page: mainPage
-  }) => {
-    const page = await goToUrl(
-      mainPage,
-      <Group>
-        <Panel id="left" />
-        <Separator />
-        <Panel id="right" />
-      </Group>
-    );
-
-    const hitAreaBox = await calculateHitArea(page, ["left", "right"]);
-    const { x, y } = getCenterCoordinates(hitAreaBox);
-
-    const panel = page.getByText("id: left");
-
-    await page.mouse.move(x, y);
-    await expect(panel).toHaveCSS("pointer-events", "auto");
-
-    await page.mouse.down();
-    await expect(panel).toHaveCSS("pointer-events", "auto");
-
-    await page.mouse.move(x + 1, y);
-    await expect(panel).toHaveCSS("pointer-events", "none");
-
-    await page.mouse.up();
-    await expect(panel).toHaveCSS("pointer-events", "auto");
-  });
-
   test("does not notify on-changed handler until pointer resize finishes", async ({
     page: mainPage
   }) => {

--- a/lib/components/group/Group.tsx
+++ b/lib/components/group/Group.tsx
@@ -118,23 +118,10 @@ export function Group({
   // TRICKY Don't read for state; it will always lag behind by one tick
   const getPanelStyles = useStableCallback(
     (groupId: string, panelId: string) => {
-      const interactionState = getInteractionState();
-      const group = getRegisteredGroup(groupId);
       const groupState = getMountedGroupState(groupId);
       if (groupState) {
-        let dragActive = false;
-        switch (interactionState.state) {
-          case "active": {
-            dragActive = interactionState.hitRegions.some(
-              (current) => current.group === group
-            );
-            break;
-          }
-        }
-
         return {
-          flexGrow: groupState.layout[panelId] ?? 1,
-          pointerEvents: dragActive ? "none" : undefined
+          flexGrow: groupState.layout[panelId] ?? 1
         } satisfies CSSProperties;
       }
 


### PR DESCRIPTION
Fixes #419 - since we do pointer capture this rule seems unnecessary but causes a bug in webkit (https://bugs.webkit.org/show_bug.cgi?id=300030) - I've tested this in safari/chrome and both work well with this fix.